### PR TITLE
Enforce the no-sorry rule in CI

### DIFF
--- a/.claude/agents/lean-dev.md
+++ b/.claude/agents/lean-dev.md
@@ -1,0 +1,28 @@
+---
+name: lean-dev
+description: Lean 4 / Mathlib proof and coding agent for StatsMLlib. Use for theorem proving, proof repair, import cleanup, Mathlib lemma hunting, and minimal Lean edits.
+---
+
+You are the `lean-dev` agent for StatsMLlib.
+
+Follow these instruction sources, in order:
+
+1. `CLAUDE.md`
+2. `.claude/skills/lean-rule/SKILL.md`
+3. `.claude/skills/mathlib-usage/SKILL.md`
+4. `ARCHITECTURE.md` for any placement question
+
+Repository-specific behavior:
+
+- Repository artifacts (code, docstrings, commit messages) are in English; reply to the user in the
+  language they used.
+- Prefer minimal diffs; no unrelated cleanup.
+- Validate with `lake env lean StatsMLlib/Path/To/File.lean` in the inner loop and
+  `LEAN_NUM_THREADS=$(sysctl -n hw.ncpu) lake build` before declaring a change ready.
+- Use the `lean-lsp` MCP tools (`lean_goal`, `lean_diagnostic_messages`, `lean_multi_attempt`,
+  `lean_loogle`, `lean_leansearch`) for goal inspection and lemma search instead of re-elaborating
+  the whole file.
+- Never leave `sorry`, `axiom`, `admit`, or `native_decide` in a proposed change, and never report a
+  proof as finished while one remains. Verify with `rg -n '\bsorry\b'` on the changed files.
+- The build must be warning-free; the lakefile enables strict style linters and `autoImplicit` is off.
+- When reporting results, include the verification command you ran and any remaining goals or blockers.

--- a/.claude/port/decls.sh
+++ b/.claude/port/decls.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# decls.sh — declaration extractor for the lean-rademacher port.
+#
+# Two uses, one implementation (see the plan, "上流そのまま vs 4.33 で書き直し"):
+#   1. generate the PR-body section C-1 requires (verbatim / rewritten / new)
+#   2. detect declaration-name drift, which §0.2-2 forbids
+#
+# Upstream is read-only text at a fixed pin; never built, never checked out.
+#
+# Usage:
+#   decls.sh names   <file.lean>              names in a local file
+#   decls.sh unames  <FoML/Path.lean>         names in an upstream file at the pin
+#   decls.sh blocks  <file.lean>              name<TAB>sha256 of each declaration block
+#   decls.sh ublocks <FoML/Path.lean>         same, upstream
+#   decls.sh compare <file.lean> <FoML/Path.lean> [<FoML/Path2.lean> ...]
+#                                             bucket local declarations against upstream
+set -uo pipefail
+
+UPSTREAM_REPO="${UPSTREAM_REPO:-/Users/milano/lean-rademacher}"
+UPSTREAM_PIN="${UPSTREAM_PIN:-bc33376}"
+
+die() { echo "decls.sh: $*" >&2; exit 2; }
+
+# Print an upstream file at the pin. Never reads the upstream working tree:
+# its checked-out branch is NOT the port target.
+ucat() {
+  git -C "$UPSTREAM_REPO" show "$UPSTREAM_PIN:$1" 2>/dev/null \
+    || die "no such upstream file at $UPSTREAM_PIN: $1"
+}
+
+# Split a Lean file into declaration blocks.
+# A block starts at a column-0 declaration keyword and runs to just before the
+# next one. Leading docstrings and attributes are attached to the block that
+# follows them, so a docstring-only change shows up as a changed declaration.
+# Emits: <name>\t<sha256 of the normalized block>
+blocks_awk='
+function flush() {
+  if (name != "") print name "\t" body_hash(body)
+}
+function body_hash(b,   c, h) {
+  c = "printf %s " quote(b) " | shasum -a 256 | cut -c1-16"
+  c | getline h
+  close(c)
+  return h
+}
+function quote(s) {
+  gsub(/'"'"'/, "'"'"'\\'"'"''"'"'", s)
+  return "'"'"'" s "'"'"'"
+}
+BEGIN { name=""; body=""; pending="" }
+{
+  line = $0
+  sub(/[ \t]+$/, "", line)
+}
+# attribute or docstring start at column 0: hold until we see the declaration
+/^@\[/ || /^\/--/ { pending = pending line "\n"; next }
+/^(private |protected |noncomputable |partial |unsafe |scoped )*(theorem|lemma|def|abbrev|instance|structure|class|inductive|axiom|example) / {
+  flush()
+  n = line
+  sub(/^(private |protected |noncomputable |partial |unsafe |scoped )*/, "", n)
+  sub(/^(theorem|lemma|def|abbrev|instance|structure|class|inductive|axiom|example)[ \t]+/, "", n)
+  sub(/[ \t{(\[:].*$/, "", n)
+  # Anonymous instances cannot be matched by name; number them so two of them
+  # never collide and get reported as both verbatim and rewritten.
+  if (n == "") { anon++; n = "<anonymous#" anon ">" }
+  name = n
+  body = pending line "\n"
+  pending = ""
+  next
+}
+{
+  if (name != "") { body = body pending line "\n"; pending = "" }
+  else { pending = "" }
+}
+END { flush() }
+'
+
+names_of() { awk "$blocks_awk" | cut -f1; }
+
+case "${1:-}" in
+  names)   [ $# -eq 2 ] || die "usage: decls.sh names <file.lean>"
+           awk "$blocks_awk" "$2" | cut -f1 ;;
+  unames)  [ $# -eq 2 ] || die "usage: decls.sh unames <FoML/Path.lean>"
+           ucat "$2" | awk "$blocks_awk" | cut -f1 ;;
+  blocks)  [ $# -eq 2 ] || die "usage: decls.sh blocks <file.lean>"
+           awk "$blocks_awk" "$2" ;;
+  ublocks) [ $# -eq 2 ] || die "usage: decls.sh ublocks <FoML/Path.lean>"
+           ucat "$2" | awk "$blocks_awk" ;;
+  compare)
+    # §0.3 is not a bijection: one upstream file may map to two StatsMLlib
+    # modules and vice versa, so both sides take a comma-separated list.
+    [ $# -eq 3 ] || die "usage: decls.sh compare <local1.lean[,local2.lean]> <FoML/A.lean[,FoML/B.lean]>"
+    tmp="${TMPDIR:-/tmp}/decls.$$"
+    mkdir -p "$tmp"
+    : > "$tmp/local"; : > "$tmp/up"
+    IFS=',' read -ra LOCALS <<< "$2"
+    IFS=',' read -ra UPS <<< "$3"
+    for f in "${LOCALS[@]}"; do
+      [ -f "$f" ] || die "no such local file: $f"
+      awk "$blocks_awk" "$f" >> "$tmp/local"
+    done
+    for u in "${UPS[@]}"; do ucat "$u" | awk "$blocks_awk" >> "$tmp/up"; done
+
+    echo "### Provenance against upstream $UPSTREAM_PIN"
+    echo
+    echo "Local:    $(for f in "${LOCALS[@]}"; do printf '`%s` ' "$f"; done)"
+    echo "Upstream: $(for u in "${UPS[@]}"; do printf '`%s` ' "$u"; done)"
+    echo
+    same=0; changed=0; new=0
+    echo "**Copied verbatim from upstream**"
+    echo
+    while IFS=$'\t' read -r n h; do
+      uh=$(awk -F'\t' -v k="$n" '$1==k{print $2; exit}' "$tmp/up")
+      if [ -n "$uh" ] && [ "$uh" = "$h" ]; then echo "- \`$n\`"; same=$((same+1)); fi
+    done < "$tmp/local"
+    [ "$same" -eq 0 ] && echo "- (none)"
+    echo
+    echo "**Rewritten for the Lean 4.27 → 4.33 diff**"
+    echo
+    while IFS=$'\t' read -r n h; do
+      uh=$(awk -F'\t' -v k="$n" '$1==k{print $2; exit}' "$tmp/up")
+      if [ -n "$uh" ] && [ "$uh" != "$h" ]; then echo "- \`$n\`"; changed=$((changed+1)); fi
+    done < "$tmp/local"
+    [ "$changed" -eq 0 ] && echo "- (none)"
+    echo
+    echo "**New in StatsMLlib (no upstream original)**"
+    echo
+    while IFS=$'\t' read -r n h; do
+      uh=$(awk -F'\t' -v k="$n" '$1==k{print $2; exit}' "$tmp/up")
+      if [ -z "$uh" ]; then echo "- \`$n\`"; new=$((new+1)); fi
+    done < "$tmp/local"
+    [ "$new" -eq 0 ] && echo "- (none)"
+    echo
+    echo "**Upstream declarations not present locally**"
+    echo
+    missing=0
+    while IFS=$'\t' read -r n h; do
+      lh=$(awk -F'\t' -v k="$n" '$1==k{print $2; exit}' "$tmp/local")
+      if [ -z "$lh" ]; then echo "- \`$n\`"; missing=$((missing+1)); fi
+    done < "$tmp/up"
+    [ "$missing" -eq 0 ] && echo "- (none)"
+    echo
+    echo "verbatim=$same rewritten=$changed new=$new upstream-only=$missing"
+    ;;
+  *) die "usage: decls.sh {names|unames|blocks|ublocks|compare} ..." ;;
+esac

--- a/.claude/port/gate.sh
+++ b/.claude/port/gate.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# gate.sh — one command to run before opening a port PR.
+#
+# Implements note/plan.md §10 (verification policy) items 1-4 and 7, plus the
+# appendix C-1 budget rule and the two failure modes the plan does not name:
+# base drift and a note/ leak. §10-5 and §10-6 cannot be scripted, so this
+# prints them as a checklist and requires a reviewer line in the ledger.
+#
+# Usage:  bash .claude/port/gate.sh [--pr NN] [--decls N] [--lines N]
+#
+# Exits 0 only if every mechanical check passes.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 2
+
+PR=""; BUDGET_DECLS=20; BUDGET_LINES=600; EXTRA_PATHS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pr)    PR="$2"; shift 2 ;;
+    --decls) BUDGET_DECLS="$2"; shift 2 ;;
+    --lines) BUDGET_LINES="$2"; shift 2 ;;
+    # Escape hatch for the infrastructure PR (00), which legitimately touches
+    # .github/ and .gitignore. A port PR must never need this.
+    --allow-path) EXTRA_PATHS="$EXTRA_PATHS $2"; shift 2 ;;
+    *) echo "gate.sh: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+
+fail=0
+ok()   { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+bad()  { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; fail=1; }
+note() { printf '        %s\n' "$1"; }
+head_() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+BASE=$(git merge-base origin/main HEAD 2>/dev/null)
+if [ -z "$BASE" ]; then
+  echo "gate.sh: cannot find merge-base with origin/main (run git fetch origin)" >&2
+  exit 2
+fi
+CHANGED=$(git diff --name-only "$BASE"...HEAD -- '*.lean')
+
+head_ "Branch"
+note "branch:     $(git rev-parse --abbrev-ref HEAD)"
+note "merge-base: $(git rev-parse --short "$BASE")"
+note "changed .lean files: $(echo "$CHANGED" | grep -c . )"
+
+# ---------------------------------------------------------------- branch shape
+head_ "Branch shape"
+
+# A port PR carries the mathematics and nothing else: StatsMLlib Lean sources,
+# plus the three documents C-1 requires be updated alongside them. Everything
+# else — note/, .claude/, CLAUDE.md, .mcp.json, *.bak, lakefile.lean, .github/ —
+# is a leak. This subsumes the note/ check: reflect/plan carries 7k lines of
+# note/, so branching from the wrong HEAD is the easiest mistake available.
+leak=0
+while read -r p; do
+  [ -z "$p" ] && continue
+  case "$p" in
+    StatsMLlib/*.lean|FILE_TREE.md|ARCHITECTURE.md|README.md|AUTHORS.md) continue ;;
+  esac
+  allowed=0
+  for extra in $EXTRA_PATHS; do
+    case "$p" in $extra) allowed=1; break ;; esac
+  done
+  [ "$allowed" -eq 1 ] && continue
+  [ "$leak" -eq 0 ] && bad "the diff contains files that are not StatsMLlib mathematics"
+  note "leak: $p"
+  leak=1
+done < <(git diff --name-only "$BASE"...HEAD)
+[ "$leak" -eq 0 ] && ok "diff contains only StatsMLlib Lean sources and the C-1 documents"
+
+if git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+  ok "branch contains origin/main (no base drift)"
+else
+  bad "origin/main is not an ancestor — run: git merge origin/main"
+fi
+
+TOTAL_ADDED=$(git diff --numstat "$BASE"...HEAD -- '*.lean' | awk '{s+=$1} END{print s+0}')
+if [ "$TOTAL_ADDED" -le "$BUDGET_LINES" ]; then
+  ok "added Lean lines: $TOTAL_ADDED (budget $BUDGET_LINES)"
+else
+  bad "added Lean lines: $TOTAL_ADDED exceeds the C-1 budget of $BUDGET_LINES — split at a boundary where both halves compile, or say so in the PR body"
+fi
+
+# ------------------------------------------------------------------- invariants
+head_ "Repository invariants (CONTRIBUTING.md)"
+
+if rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/ >/dev/null 2>&1; then
+  bad "sorry / admit / axiom / native_decide present"
+  rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/ | sed 's/^/        /'
+else
+  ok "no sorry / admit / axiom / native_decide in StatsMLlib/"
+fi
+
+# Import tier from ARCHITECTURE.md: {Order, MeasureTheory, Topology,
+# LinearAlgebra} -> Analysis -> Probability -> LearningTheory -> Statistics.
+# A module must not import from a later tier.
+head_ "Import direction (§10-7, ARCHITECTURE.md)"
+tier() {
+  case "$1" in
+    Order|MeasureTheory|Topology|LinearAlgebra) echo 0 ;;
+    Analysis)      echo 1 ;;
+    Probability)   echo 2 ;;
+    LearningTheory) echo 3 ;;
+    Statistics)    echo 4 ;;
+    *) echo -1 ;;
+  esac
+}
+tier_bad=0
+for f in $CHANGED; do
+  [ -f "$f" ] || continue
+  own=$(echo "$f" | sed -n 's|^StatsMLlib/\([^/]*\)/.*|\1|p')
+  [ -z "$own" ] && continue
+  ot=$(tier "$own"); [ "$ot" -lt 0 ] && continue
+  while read -r dep; do
+    dt=$(tier "$dep"); [ "$dt" -lt 0 ] && continue
+    if [ "$dt" -gt "$ot" ]; then
+      bad "$f ($own, tier $ot) imports StatsMLlib.$dep (tier $dt)"
+      tier_bad=1
+    fi
+  done < <(grep -h '^import StatsMLlib\.' "$f" | sed -n 's|^import StatsMLlib\.\([^.]*\)\..*|\1|p')
+done
+[ "$tier_bad" -eq 0 ] && ok "no module imports from a later tier"
+
+# ------------------------------------------------------------------------ build
+head_ "Build"
+if lake build >/tmp/gate-build.$$ 2>&1; then
+  ok "lake build is green"
+else
+  bad "lake build failed"
+  tail -30 /tmp/gate-build.$$ | sed 's/^/        /'
+fi
+
+# lake build only re-emits warnings for files it rebuilt, so re-elaborate each
+# changed file: its output must be completely empty.
+head_ "Warnings (CONTRIBUTING.md requires a clean build)"
+warn_bad=0
+for f in $CHANGED; do
+  [ -f "$f" ] || continue
+  out=$(lake env lean "$f" 2>&1)
+  if [ -n "$out" ]; then
+    bad "$f is not clean"
+    echo "$out" | head -10 | sed 's/^/        /'
+    warn_bad=1
+  fi
+done
+[ "$warn_bad" -eq 0 ] && ok "every changed file elaborates with no output"
+
+# --------------------------------------------------- standalone import (§10-4)
+head_ "Standalone import (§10-4)"
+NEWFILES=$(git diff --name-only --diff-filter=A "$BASE"...HEAD -- 'StatsMLlib/*.lean')
+if [ -z "$NEWFILES" ]; then
+  note "no new modules in this PR"
+else
+  for f in $NEWFILES; do
+    mod=$(echo "$f" | sed 's|/|.|g; s|\.lean$||')
+    probe="${TMPDIR:-/tmp}/gate-import-$$.lean"
+    echo "import $mod" > "$probe"
+    if out=$(lake env lean "$probe" 2>&1) && [ -z "$out" ]; then
+      ok "import $mod works standalone"
+    else
+      bad "import $mod fails standalone"
+      echo "$out" | head -5 | sed 's/^/        /'
+    fi
+  done
+fi
+
+# --------------------------------------------------------------- human gates
+head_ "Human checks — NOT scripted (§10-5, §10-6)"
+cat <<'EOF'
+        These cannot be automated. Record a reviewer line in
+        .claude/port/ledger.md before opening the PR.
+
+        §10-5  linear predictors: does the complexity constant in the threshold
+               match the existing empirical bound? does the McDiarmid exponent
+               use the uniform function-value bound (X * W or Xinf * W, not C)?
+               are 0 < n and the positive-radius hypotheses stated?
+        §10-6  Dudley: going from the one-sided version to the absolute-value
+               version, is the inequality direction still correct?
+
+        Declaration names (§0.2-2): run
+          bash .claude/port/decls.sh compare <local files> <upstream files>
+        and confirm the "upstream-only" bucket contains nothing you meant to port.
+EOF
+
+head_ "Result"
+if [ "$fail" -eq 0 ]; then
+  printf '  \033[32mall mechanical checks passed\033[0m'
+  [ -n "$PR" ] && printf ' (PR %s)' "$PR"
+  echo
+  exit 0
+else
+  printf '  \033[31mgate failed\033[0m — fix the FAIL lines above\n'
+  exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "enabledMcpjsonServers": ["lean-lsp"],
+  "permissions": {
+    "allow": [
+      "Bash(lake build:*)",
+      "Bash(lake env lean:*)",
+      "Bash(lake env:*)",
+      "Bash(lake exe:*)",
+      "Bash(rg:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "mcp__lean-lsp"
+    ]
+  }
+}

--- a/.claude/skills/lean-rule/SKILL.md
+++ b/.claude/skills/lean-rule/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: lean-rule
+description: Execution workflow for Lean proof work in StatsMLlib (plan → sorry-skeleton → one-error-at-a-time iteration → Mathlib search → minimal diffs). Use when writing, repairing, or extending any proof in a .lean file.
+---
+
+# Lean execution workflow
+
+`../../workflow/proof-planning.md` is only for **proof planning and replanning**. Do not auto-apply
+its formatting rules or its olympiad-style syntax restrictions during implementation. During
+implementation, `CLAUDE.md` and this skill come first.
+
+The skeleton-first rule below is for proof construction — new proofs, proof repair, substantial
+proof extension. Do not apply it to non-semantic refactoring or cleanup passes.
+
+## Routing
+
+- Writing or repairing a proof in a `.lean` file: this skill is the primary workflow, then
+  `mathlib-usage` for lemma, import, and tactic decisions.
+- "Does this lemma exist", import minimization, tactic choice: `mathlib-usage`.
+- Where a declaration belongs: `ARCHITECTURE.md`.
+
+## Workflow
+
+1. Plan with `../../workflow/proof-planning.md` Part 1.
+   - The plan is a transient artifact unless the user asked to see planning output.
+   - Do not pause after planning when the next implementation step is already clear.
+2. For non-trivial proofs, first write a visible skeleton in the file: many small
+   `have ... := by sorry` steps exposing the main dependency chain.
+   - This is the default first artifact of implementation, not a private note.
+   - Skip it only when the proof closes immediately with a tiny local argument.
+3. Two phases:
+   - Phase 1: get a type-checkable `have ... := by sorry` skeleton.
+   - Phase 2: fill the skeleton from the top until no `sorry` remains.
+4. Keep each `have` mathematically meaningful and fillable in roughly 1–5 lines. Split any `have`
+   that grows past that.
+5. Implement in dependency order, top down.
+6. For each `have`, iterate strictly:
+   - Apply a minimal edit (1–5 lines) around the **topmost** error only.
+   - Observe immediately: `lake env lean StatsMLlib/Path/To/File.lean`, or `lean_goal` /
+     `lean_diagnostic_messages` from the `lean-lsp` MCP server.
+   - Re-check before making any further speculative edit. Never batch guessed fixes.
+   - In Phase 1 and early Phase 2, non-semantic lint warnings are not blockers: defer `longLine`,
+     `unusedSimpArgs`, `unnecessarySimpa`. Prioritize type errors, goal-shape mismatches,
+     elaboration failures, and heartbeat errors.
+   - On a heartbeat error, isolate the heavy fragment, temporarily restore just that fragment to
+     `by sorry`, keep the outer skeleton moving, and revisit with a smaller target.
+   - If one `have` stays open 5 times or the errors worsen, re-plan.
+7. Before stopping, run `lake env lean` on the target file. If compile errors, unsolved goals, or
+   elaboration failures remain, keep working on the topmost one.
+8. Before stopping, run `rg -n '\bsorry\b'` on the target file, extended to every changed Lean file
+   when the work spans more than one. Any remaining proof `sorry` means the work is unfinished —
+   continue from the easiest one.
+9. Once the deferred lint warnings are the only thing left, clear them: the build must be
+   warning-free (`CONTRIBUTING.md`).
+10. Finish with `lake env lean` on the changed files, and `lake build` before proposing the change.
+11. If stuck, re-plan with `../../workflow/proof-planning.md` Part 2.
+
+## Implementation principles
+
+- Keep changes minimal and local.
+- Prefer an explicit `have ... := by sorry` skeleton over attempting one large direct proof script.
+- Stabilize the proof first; clear deferred non-semantic lint after the dependency chain works.
+- Temporary `have`s are fine while structuring, but collapse one-off scaffolding that no longer helps.
+- A remaining `sorry` is never an acceptable stopping point, and never part of a proposed change.
+- For subgoals, avoid `simp [*]` and huge `simp` sets; prefer `rw` / `simpa` / `simp only` / `simp_rw`.
+- Do not chain a fragile `rw` right after `simp`; insert `have h : ... := by ...` then `simpa using h`.
+- `ring` / `ring_nf` for commutative normalization; `noncomm_ring`, `abel`, or `module` outside
+  commutative rings. `field_simp` in tiny helpers for denominators, `fun_prop` / `measurability`
+  for regularity, `positivity` / `finiteness` for sign and finiteness side goals.
+- `grind` is a legitimate closer for arithmetic, order, and first-order leaves, and Mathlib leans on
+  it heavily at this pin; do not make it — or `aesop` — the main weapon for measure, integral, or
+  spectral goals. Structure the proof, then let it close the leaves.
+- `autoImplicit` is off: bind every variable explicitly.
+
+## Standard observation loop
+
+1. `lake env lean StatsMLlib/Path/To/File.lean`
+2. For the top error, `lean_goal` / `lean_term_goal`
+3. Minimal fix for that single error
+4. Re-check immediately
+5. Only then look at the new top error
+
+`lean_multi_attempt` is the cheap way to compare several candidate tactics at one position without
+editing the file. `lean_run_code` is for `#check` and throwaway snippets.
+
+## Role and interaction
+
+Proof work has a repo-specific stopping rule that overrides ordinary judgment about when a task is
+done:
+
+- While compile errors, unsolved goals, or relevant `sorry`s remain in the target file, keep working
+  on the topmost one. A partially closed skeleton is not a deliverable, and a progress report is not
+  a reason to stop.
+- One failed approach is not a blocker: re-search, re-plan, split the goal, or isolate the heavy
+  fragment before considering the line of attack exhausted.
+- The question worth asking is the design one — where a declaration is owned, which of two API shapes
+  the library should commit to (`ARCHITECTURE.md`, `note/plan.md` appendix C). Ask those early rather
+  than proving the wrong statement well. Do not ask which tactic or lemma to try; that is answerable
+  from the goal, the diagnostics, and search.
+
+## Replanning triggers
+
+Re-plan with `../../workflow/proof-planning.md` Part 2 if any holds:
+
+1. The same approach fails 3 times in a row.
+2. The same `have` is edited 5+ times without closing.
+3. Errors grow more complex after fixes.
+4. One `have` proof stretches beyond ~10 lines.
+
+When replanning, split the current `have` into smaller ones and search for existing lemmas first.
+
+## Heartbeat recovery
+
+- Trigger only on an actual heartbeat error (`maximum heartbeats exceeded` and similar).
+- Isolate the heavy fragment first: split the declaration, move the expensive subgoal into a smaller
+  `have`, or factor a helper lemma.
+- Temporarily replacing only the heavy fragment with `by sorry` is acceptable mid-loop.
+- On return, reduce elaboration cost structurally: shrink `simp` / `rw` scope, add type annotations,
+  break large terms into `let` / `have`, reduce instance search.
+- Only after that, consider `set_option maxHeartbeats <n> in` locally, or
+  `set_option synthInstance.maxHeartbeats <n> in` when typeclass search is the cause.
+- Common causes: `simp` / `rw` explosions, oversized declarations, coercion-heavy terms, weak
+  annotations, expensive typeclass search.
+
+## Commit discipline
+
+- Commit only when the user asks, at the granularity they ask for.
+- Stage only changed tracked files with `git add <file>`; avoid unrelated untracked files.
+- Add `Co-authored-by` trailers for co-written work (`CONTRIBUTING.md`).

--- a/.claude/skills/mathlib-usage/SKILL.md
+++ b/.claude/skills/mathlib-usage/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: mathlib-usage
+description: Mathlib usage for StatsMLlib — lemma discovery and existence checks, import policy, tactic preference order, simp discipline. Use when looking for a lemma, deciding imports, or choosing a tactic.
+---
+
+# Mathlib usage
+
+## Basics
+
+- Mathlib is a dependency of the library; its declarations are free to use.
+- Add imports sparingly and only the ones actually needed. Prefer `open` / `open scoped` / `local`
+  over adding an import.
+- Respect the import tier in `ARCHITECTURE.md`: `{MeasureTheory, Topology, LinearAlgebra}` →
+  `Analysis` → `Probability` → `LearningTheory` → `Statistics`. A module never imports from a later
+  tier. Do not rely on transitive imports implicitly; after changing imports, re-check the edited
+  file and its downstream importers.
+- Try existing StatsMLlib and Mathlib declarations first. Only if none fits, add a minimal helper.
+- Never invent lemma names. Confirm a name exists before using it.
+- Do not ask the user which lemma to try when local search, diagnostics, or a small snippet answers it.
+
+## Search flow
+
+0. Mathlib sources live at `.lake/packages/mathlib/Mathlib`. If that path is missing, run `lake update`.
+1. Build keywords: synonyms, case variants, typeclass and structure names; search notation as a string.
+2. Narrow with `rg -n "<keyword>" .lake/packages/mathlib/Mathlib`.
+3. Also search the library itself: `rg -n "<keyword>" StatsMLlib` — the result may already exist here.
+4. Read the hits: check hypotheses, related lemmas, `[simp]` / `[grind]` / `[fun_prop]` attributes.
+   - Mathlib at this pin has migrated to the Lean module system: 8241 of its 8311 files begin with
+     `module` and write `public import Mathlib.X`. StatsMLlib does **not** use the module system.
+     Never copy an import line verbatim out of Mathlib source — `public import` outside a `module`
+     file fails with `cannot use 'public import' without 'module'`. Write plain `import Mathlib.X`.
+   - Declaration lines are still bare `theorem` / `lemma`, so `rg` patterns are unaffected.
+5. Confirm existence with `lean_run_code` (`#check`) or `lean_hover_info`.
+6. The `lean-lsp` MCP server is usually faster than guessing keywords: `lean_local_search` (by name,
+   across this project and Mathlib), `lean_leansearch` (natural language), `lean_loogle` (by shape),
+   `lean_state_search` and `lean_hammer_premise` (from the current goal).
+7. Confirm finally with `lake env lean StatsMLlib/Path/To/File.lean`.
+
+## Tactic preference order
+
+1. **Local cleanup** — `rw`, `simpa`, `simp only [...]`, `simp_rw [...]`. Handle subgoal rewrites here.
+2. **Specialized** — `fun_prop`, `measurability`, `positivity`, `finiteness`, `ring_nf`, `field_simp`,
+   `linarith`, `nlinarith`, `omega`, `gcongr`, `linear_combination`, `bound`, `order`.
+   - `bound` closes routine `0 ≤ x` / `x ≤ y` bound goals by structural recursion; useful for the
+     nonnegativity and monotonicity side conditions that appear all over complexity estimates.
+   - `order` decides goals in linear and partial orders from the hypotheses in context.
+   - `module` / `abel` / `noncomm_ring` cover the non-commutative and module-valued analogues of `ring`.
+3. **General automation** — `grind`, `aesop`. `grind` is now heavily used inside Mathlib itself
+   (~5900 call sites at the pinned version, up ~30% over 2026 H1, with `@[grind]` attributes on
+   library lemmas). Treat it as a legitimate closer for arithmetic, order, and first-order goals,
+   and try it on a stuck side goal before hand-rolling a chain of rewrites. It is still not the
+   right main strategy for measure, integral, or spectral goals — there, structure the proof first
+   and let `grind` close the leaves.
+
+## simp discipline
+
+- Do not routinely use `simp [*]` on subgoals.
+- Do not flood `simp` with AC lemmas (`mul_assoc`, `mul_comm`, `add_assoc`, `add_comm`).
+- Do not unfold large definitions without a purpose.
+- Do not chain a fragile `rw` right after `simp`; insert a `have` and `simpa using` it.
+- When `simp?` suggests a `simp only`, pin it — it is both faster and more stable.
+- Under binders, use `simp_rw` when rewrite order matters.
+
+## Goal-oriented patterns
+
+**Structural properties** (`Continuous*`, `Measurable*`, `Integrable*`, `Differentiable*`): `fun_prop`
+is the engine — `measurability` is now a backward-compatibility wrapper that delegates to it for
+`Measurable` / `AEMeasurable` / `StronglyMeasurable` / `AEStronglyMeasurable`. Reach for `fun_prop`
+first; when tagging a new lemma, use `@[fun_prop]`, not `@[measurability]`. Side goals that reduce to
+order facts go to `positivity` or a short `linarith`.
+
+**Algebraic normalization**: `ring_nf` for polynomial-style normalization; `noncomm_ring` / `abel` /
+`module` outside commutative rings; `field_simp` only where denominators must be cleared;
+`linear_combination` when a linear relation closes the goal.
+
+**Rewriting-heavy goals**: `simp_rw` under binders, small explicit `simp only [...]` sets, targeted
+local rewrites (`rw [mul_assoc]`) rather than large AC bundles.
+
+**Inequalities**: `positivity` first for nonnegativity, then `linarith` / `nlinarith` / `omega` by
+arithmetic domain, `gcongr` for congruence-style monotonicity steps.
+
+## LSP helpers
+
+- `lean_term_goal` — expected type at a position
+- `lean_goal` — goal and context
+- `lean_diagnostic_messages` — distinguishes import and typeclass issues from proof errors
+- `lean_hover_info` — signature and docstring of a name
+- `lean_multi_attempt` — compare candidate tactics without editing
+- `lean_declaration_file` / `lean_references` — read a definition in place, see how it is used
+
+Final confirmation is always `rg` / `#check` / `lake env lean`.

--- a/.claude/workflow/proof-planning.md
+++ b/.claude/workflow/proof-planning.md
@@ -1,0 +1,108 @@
+---
+description: Lean 4 proof planning guide (initial planning and dynamic replanning)
+---
+
+# Lean 4 Proof Planning Guide
+
+Use this document for **planning and replanning proofs**.
+During implementation, repo-local rules in `CLAUDE.md` and `.claude/skills/lean-rule/SKILL.md` take priority.
+
+Some formatting rules here are inspired by olympiad-style planning and should not be auto-applied to general Lean implementation (measure/topology/operator/matrix).
+
+## Overview
+
+This guide covers two scenarios:
+
+1. **Initial Planning**: build a proof plan from the theorem statement.
+2. **Dynamic Replanning**: replan the remaining proof from proven parts and stuck goals.
+
+## Common rules (repo-local planning)
+
+1. For Lean theorem formalization, planning output should normally be a `have ... := by sorry` skeleton.
+   - A plain list of `have` statements is acceptable only for tiny local arguments or planning-only requests.
+   - Treat that output as an internal or transient artifact unless the user explicitly asked for planning output.
+   - When implementation can proceed safely, do not stop after producing the plan.
+2. Keep `have` granularity small (aim 1–5 lines to fill).
+3. Use existing mathlib names; do not coin lemma names.
+4. Introduce new variables/functions/indices locally with `let` / `set` / `have` / explicit binders.
+5. Match interval/set notation to downstream API; using `Set.Icc`, `Set.Ioo`, etc. is fine.
+6. Add numeric type annotations when ambiguity exists (division/subtraction/coercions).
+7. Use existing named theorems/inequalities when they shorten proofs and fit the API.
+8. Always write multiplication `*` explicitly.
+9. Avoid chained inequalities; split with `∧` if needed.
+10. In replanning, preserve proven parts and split stuck goals into smaller `have`s.
+11. Use notation-first style **by default** for seeds, expansions, and claims.
+   - If notation is unavailable or ambiguous, fall back to fully qualified names, and add a short note in the plan that explains why.
+
+## Part 1: Initial Planning
+
+### Task
+
+Analyze a Lean 4 theorem statement and design a coherent chain of `have` steps from assumptions to conclusion.
+
+Break complex arguments into small lemmas that can be implemented in the same session. In planning, prioritize dependencies and order over full proofs, then continue directly into implementation unless blocked.
+
+### Instructions
+
+- Understand the main structure of the theorem.
+- Prefer `have` steps that form key branching points over immediate closures.
+- Order `have`s as a logical chain toward the theorem.
+- Use `have ... := by sorry` skeletons by default so the dependency order becomes a type-checkable first draft.
+
+### Example (format)
+
+**Input:**
+
+```lean
+theorem sample (x : ℝ) (hx : 0 < x) : x + x = 2 * x := by
+```
+
+**Planning Output:**
+
+```lean
+have h1 : x + x = x * 2 := by sorry
+have h2 : x * 2 = 2 * x := by sorry
+```
+
+### Next step: immediate continuation into implementation
+
+1. Place each `have` with `by sorry` temporarily.
+2. Fill them one by one, fixing errors top-down.
+3. If stuck, go to Part 2 (Dynamic Replanning).
+4. Do not stop after this planning stage when a safe implementation step is already clear.
+
+## Part 2: Dynamic Replanning
+
+### Task
+
+When progress stalls, replan the remaining proof from the current theorem state, the already established local facts, and the current outstanding goals.
+
+Use the local file, current diagnostics, visible goals, and existing partial proof as the default source of truth. Do not ask the user to restate proven steps or stuck goals; continue from the available context.
+
+### Additional Rules
+
+#### 11. Preserve Established Steps
+
+Keep already established proof steps unless there is a clear reason they must be changed.
+
+#### 12. Provide a Complete Updated Plan
+
+Update the local proof plan so it includes retained steps and newly introduced helper steps, then resume implementation from that updated plan.
+
+#### 13. Ensure Logical Continuity
+
+Insert new helper `have` steps in a natural logical order. Prefer smaller intermediate facts over repeating the stuck goal in slightly different words.
+
+### Practical Guidance for Dynamic Replanning
+
+- Do not attack the stuck goal directly if simpler side goals can be isolated first.
+- Reuse proven local facts before introducing new ones.
+- Prefer narrowing the gap with smaller helper lemmas over discarding the whole plan.
+- Treat replanning as a way to continue implementation, not as a stopping point by itself.
+- Escalate to the user only when the remaining ambiguity is a library-design decision; otherwise choose the most conservative locally supported continuation.
+
+## Notes
+
+- This document is a planning helper, not the repo-wide implementation policy.
+- Using `Set.Icc` / `Set.Ioo`, introducing new helper vars/indices/`let` is fine if it matches project API.
+- In theorem formalization, a type-checkable `have ... := by sorry` skeleton is the normal first implementation artifact.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,11 @@ jobs:
       - uses: leanprover/lean-action@v1
         with:
           check-reservoir-eligibility: true
+          # CONTRIBUTING.md forbids `sorry`, `axiom`, `admit` and `native_decide`,
+          # but nothing enforced it: `sorry` is only a warning, so `lake build`
+          # exits 0 and the job stays green. `axiom-audit` fails the build when a
+          # declaration transitively depends on an axiom outside
+          # `propext,Classical.choice,Quot.sound` — which catches `sorryAx` from
+          # `sorry`/`admit`, the per-declaration axiom `native_decide` introduces,
+          # and any hand-written `axiom`.
+          axiom-audit: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,14 @@
 .DS_Store
 .idea/
 .vscode/
+
+# Editor and script backup files. `sed -i.bak` leaves these under StatsMLlib/,
+# where they are invisible to `lake build` (the lakefile globs `.lean` only) and
+# would otherwise ride along into a commit.
+*.bak
+*.bak[0-9]
+
+# Local porting state: the ledger and migration notes for the lean-rademacher
+# port. Working artifacts, not library content. The scripts beside them
+# (gate.sh, decls.sh) are deliberately not ignored.
+/.claude/port/*.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "lean-lsp": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "lean-lsp-mcp",
+        "lean-lsp-mcp",
+        "--lean-project-path",
+        "."
+      ],
+      "env": {}
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,149 @@
+# Claude / Lean workflow (StatsMLlib)
+
+StatsMLlib is a Lean 4 + Mathlib library for probability, empirical processes, statistical learning
+theory, and statistics.
+
+This file is the authoritative runtime instruction set for agent work in this repository.
+If external templates conflict with this file, follow this file.
+
+## Sources of truth
+
+Read these before making non-trivial changes:
+
+- `ARCHITECTURE.md` — layer ownership, import direction, module naming. Binding for placement decisions.
+- `CONTRIBUTING.md` — build and submission requirements.
+- `note/plan.md` — the current work plan (Rademacher complexity → generalization bounds port).
+  `note/plan.en.md` is the English rendering; `note/upstream/` holds the upstream originals.
+- `FILE_TREE.md` — module-by-module map of the library.
+
+## Skills index
+
+Repository-local skills under `.claude/skills/`:
+
+- `lean-rule` — execution workflow for Lean proof work (plan → skeleton → error-driven iteration).
+- `mathlib-usage` — lemma discovery, imports, tactic preference order.
+
+Planning helper: `.claude/workflow/proof-planning.md` (planning and replanning only).
+
+Priority when several apply:
+
+1. `CLAUDE.md` (this file)
+2. `ARCHITECTURE.md` / `CONTRIBUTING.md` for placement and submission rules
+3. `lean-rule` (execution workflow for Lean proof work)
+4. `mathlib-usage`
+
+## Common commands
+
+- Type-check one file: `lake env lean StatsMLlib/Path/To/File.lean`
+- Build the whole library: `LEAN_NUM_THREADS=$(sysctl -n hw.ncpu) lake build`
+  (`CONTRIBUTING.md` writes `nproc`; on macOS use `sysctl -n hw.ncpu`.)
+- Mathlib search: `rg -n "<pattern>" .lake/packages/mathlib/Mathlib`
+- Repo search: `rg -n "<pattern>" StatsMLlib`
+
+`lake env lean <file>` is the fast inner loop; `lake build` is the gate before proposing a change.
+
+## Lean LSP tools
+
+The `lean-lsp` MCP server (`.mcp.json`, `lean-lsp-mcp` 0.30.0 via `uvx`) exposes 23 tools built on
+the Lean language server. The ones that matter day to day:
+
+Goal and diagnostic inspection:
+
+- `lean_goal` — goal and context at a position
+- `lean_term_goal` — expected type at a position
+- `lean_diagnostic_messages` — diagnostics for a file
+- `lean_hover_info` — signature and docstring of a name
+- `lean_file_outline` — declarations in a file
+- `lean_declaration_file` / `lean_references` — jump to a definition, find its uses
+
+Experimentation:
+
+- `lean_multi_attempt` — try several tactics at a position without editing the file
+- `lean_run_code` — `#check` and other minimal snippets
+- `lean_verify` / `lean_build` — verify a file or the project
+- `lean_minimal_hypotheses` / `lean_profile_proof` — trim unused hypotheses, find slow steps
+
+Lemma search:
+
+- `lean_local_search` — search this project and Mathlib by name
+- `lean_leansearch` — natural-language search
+- `lean_loogle` — search by shape or signature
+- `lean_state_search` / `lean_hammer_premise` — suggestions from the current goal
+
+Prefer these over re-running `lake env lean` for goal inspection: they answer "what is the goal here"
+without a full re-elaboration. Still confirm the final state with `lake env lean <file>`.
+
+## Standard proof workflow
+
+1. Read the target statement and its surrounding module.
+2. Plan a short tactic strategy and a theorem-reuse path.
+3. Use skeleton-first for non-trivial proofs (`have ... := by sorry` blocks), then fill from the top.
+4. Iterate with Lean diagnostics: fix one top error at a time, re-check after each fix.
+5. Finish only after every `sorry` is gone and the file type-checks.
+
+Details are in `.claude/skills/lean-rule/SKILL.md`.
+
+## Repository invariants
+
+These come from `CONTRIBUTING.md` and are not negotiable in committed code:
+
+- No `sorry`, `axiom`, `admit`, or `native_decide`. A `sorry` skeleton is a transient drafting
+  device inside a working session, never a stopping point and never a proposed change.
+- No warnings or info messages in the build. `lakefile.lean` enables `linter.longLine`,
+  `linter.cdot`, `linter.style.lambdaSyntax`, `linter.refine`, `linter.oldObtain`, and others;
+  `autoImplicit` is off, so every variable must be bound explicitly.
+- Remove unused parameters instead of hiding them with `_`.
+- Reuse existing StatsMLlib and Mathlib declarations before adding new infrastructure.
+- New modules need a Mathlib-style file header and a module docstring.
+- Preserve existing copyright and `Authors` headers; add significant authors when you add substance.
+
+## Reading Mathlib source
+
+Mathlib at this pin (v4.33.0, 2026-08-10) uses the Lean module system: 8241 of its 8311 files open
+with `module` and write `public import Mathlib.X`. StatsMLlib does not. When lifting code or imports
+out of Mathlib, strip `module` / `public` — `public import` in a non-module file is a hard error.
+
+## Placement rules
+
+- Every Lean module lives under one of the seven layer-one directories. No Lean files directly in
+  `StatsMLlib/`.
+- Respect the import tier: `{MeasureTheory, Topology, LinearAlgebra}` → `Analysis` → `Probability`
+  → `LearningTheory` → `Statistics`. Never import from a later tier.
+- Do not add `Main.lean`, `Infrastructure.lean`, or an unqualified `Defs.lean`.
+- When a declaration could go in two places, `ARCHITECTURE.md` "Layer-one ownership" decides.
+- Changing where a declaration is owned is a design decision: state it explicitly rather than
+  moving it silently.
+
+## Proof style
+
+- Keep steps small and local.
+- Prefer `exact`, `simpa`, `rw`, `constructor`, `cases`, `intro`, `apply` before heavier automation.
+- Prefer `simp only [...]` over broad `simp [*]` in fragile goals.
+- Use explicit `*` and `^` notation.
+- Prefer project notation and existing abbreviations over fully qualified names where they exist.
+
+## Delegation
+
+Claude Code has subagents; use them where Lean work is naturally parallel or search-heavy.
+
+- `lean-dev` (`.claude/agents/lean-dev.md`) — a self-contained proof obligation: one lemma, one
+  repair, one import cleanup. It inherits the main model, so it is fit for hard proofs, not just
+  mechanical ones. Delegating keeps a long `lake env lean` / search loop out of the main context.
+- `Explore` — "where does this concept already live, in StatsMLlib or Mathlib" questions that would
+  otherwise dump many file excerpts into context.
+
+Do not delegate a step whose result you need in order to choose the next one; the round trip costs
+more than doing it inline.
+
+## Safety and operations
+
+- Keep edits minimal and task-local; avoid unrelated cleanup in the same change.
+- Do not run destructive git commands unless explicitly requested.
+- Do not commit unless explicitly requested. Stage only changed tracked files with `git add <file>`.
+- PRs are kept small; `note/plan.md` appendix C marks the ones that touch library design and need
+  discussion first.
+
+## Language
+
+- Repository artifacts (Lean code, docstrings, comments, commit messages, PR text) are in English.
+- Conversation with the user follows the user's language.


### PR DESCRIPTION
`CONTRIBUTING.md` states:

> Do not introduce `sorry`, `axiom`, `admit`, or `native_decide`.

Nothing checked for it. This adds the check.

## Why it was not caught

`sorry` is a **warning**, not an error, so `lake build` exits 0 and CI passes. Verified locally:

```
$ lake env lean SorryProbe.lean
SorryProbe.lean:3:8: warning: declaration uses `sorry`
$ echo $?
0
```

`leanprover/lean-action@v1` does have the mechanism for this — the `axiom-audit`
input — but it defaults to `false`, and this workflow does not set it. So a `sorry`
merged today would go green.

## What this changes

`axiom-audit: true` fails the build when any declaration transitively depends on an
axiom outside the action's default allowlist `propext, Classical.choice, Quot.sound`.
That covers three of the four names `CONTRIBUTING.md` lists, plus stray `axiom`
declarations:

| Construct | Axiom introduced | In the allowlist? |
|---|---|---|
| `sorry` / `admit` | `sorryAx` | no → build fails |
| `native_decide` | `<decl>._native.native_decide.ax_1_1` | no → build fails |
| hand-written `axiom` | itself | no → build fails |

Verified locally with `#print axioms`.

## This does not turn `main` red

Checked the transitive axiom dependencies of five representative top-level results
before proposing the change:

```
'dudley_entropy_integral'' depends on axioms: [propext, Classical.choice, Quot.sound]
'uniform_deviation_tail_bound_separable' depends on axioms: [propext, Classical.choice, Quot.sound]
'linear_predictor_l1_bound' depends on axioms: [propext, Classical.choice, Quot.sound]
'linear_predictor_l2_bound' depends on axioms: [propext, Classical.choice, Quot.sound]
'mcdiarmid_inequality_pos' depends on axioms: [propext, Classical.choice, Quot.sound]
```

`rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` also returns nothing, so
the tree starts from a clean baseline.

## The `.gitignore` change

`*.bak` and `*.bak[0-9]`. `sed -i.bak` leaves backups next to the file it edits; under
`StatsMLlib/` those are invisible to `lake build`, because `lakefile.lean` globs
`.lean` submodules only, so a stray `Foo.lean.bak` would pass CI and land in the
repository. This happened once during local work.

`/.claude/port/*.md` ignores local porting state (a work ledger and migration notes)
while deliberately leaving the scripts beside them tracked.

## Not included

Narrowing the `on: push` trigger to `main`. It currently runs on every push to every
branch, which with this change also runs an axiom audit each time. That is a separate
question and a separate change.

## Context

Groundwork for the Rademacher-complexity port, whose plan requires every PR to be
green with zero `sorry` carried between PRs. That rule needs an enforcement point
before the first porting PR, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
