### PR TITLE
Add the Rademacher sign functional and sign symmetrization

### DIFF
--- a/StatsMLlib/LearningTheory/Rademacher/Defs.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Defs.lean
@@ -16,6 +16,9 @@ Core definitions for empirical Rademacher complexity and uniform deviations.
 * `Signs`: finite vectors of Rademacher signs.
 * `empiricalRademacherComplexity`: empirical Rademacher complexity of a function class.
 * `rademacherComplexity`: expected empirical Rademacher complexity.
+* `normalizedRademacherSum`: the normalized signed sample sum for one hypothesis.
+* `empiricalRademacherFunctional`: the common functional `φ`-averaging those sums,
+  specializing to the absolute and one-sided complexities at `φ = abs` and `φ = id`.
 
 ## Main results
 
@@ -62,5 +65,45 @@ def rademacherComplexity (n : ℕ) (f : ι → 𝒳 → ℝ) (μ : Measure Ω) (
 def empiricalRademacherComplexity_without_abs (n : ℕ) (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳) : ℝ :=
   (Fintype.card (Signs n) : ℝ)⁻¹ *
     ∑ σ : Signs n, ⨆ i, (n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * f i (S k)
+
+/--
+The normalized signed sample sum associated with a hypothesis `h`:
+
+`normalizedRademacherSum n F S σ h =
+  n⁻¹ * ∑ k, σ k * F h (S k)`.
+-/
+def normalizedRademacherSum
+    (n : ℕ) (F : ι → 𝒳 → ℝ) (S : Fin n → 𝒳)
+    (σ : Signs n) (h : ι) : ℝ :=
+  (n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * F h (S k)
+
+/--
+The common finite-sign functional underlying empirical Rademacher
+complexities:
+
+`empiricalRademacherFunctional n φ F S =
+  |Signs n|⁻¹ * ∑ σ, ⨆ h, φ (normalizedRademacherSum n F S σ h)`.
+
+Taking `φ = abs` gives absolute empirical Rademacher complexity, while
+`φ = id` gives the one-sided version.
+-/
+def empiricalRademacherFunctional
+    (n : ℕ) (φ : ℝ → ℝ) (F : ι → 𝒳 → ℝ) (S : Fin n → 𝒳) : ℝ :=
+  (Fintype.card (Signs n) : ℝ)⁻¹ *
+    ∑ σ : Signs n, ⨆ h, φ (normalizedRademacherSum n F S σ h)
+
+@[simp]
+theorem empiricalRademacherFunctional_abs
+    (n : ℕ) (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳) :
+    empiricalRademacherFunctional n abs f S =
+      empiricalRademacherComplexity n f S :=
+  rfl
+
+@[simp]
+theorem empiricalRademacherFunctional_id
+    (n : ℕ) (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳) :
+    empiricalRademacherFunctional n id f S =
+      empiricalRademacherComplexity_without_abs n f S :=
+  rfl
 
 end

--- a/StatsMLlib/LearningTheory/Rademacher/Signs.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Signs.lean
@@ -17,12 +17,20 @@ Algebraic and probability-mass-function representations of finite Rademacher sig
 ## Main definitions
 
 * `rademacher_flip`: flips one coordinate of a sign vector.
+* `signSymmetrization`: the class enlarged by pointwise negatives, indexed by `ι × Bool`.
+* `IsNegClosed`: the predicate that a class already contains the negative of each member.
+* `empiricalRademacherFunctional_pmf`: the sign functional written as a PMF integral.
 
 ## Main results
 
 * `rademacher_orthogonality`: distinct Rademacher coordinates are orthogonal.
 * `empiricalRademacherComplexity_eq_empiricalRademacherComplexity_pmf`: PMF representation of
   empirical Rademacher complexity.
+* `empiricalRademacherComplexity_eq_without_abs_signSymmetrization`: the absolute complexity of a
+  class equals the one-sided complexity of its sign symmetrization, which removes the absolute
+  value at the cost of doubling the index type.
+* `empiricalRademacherComplexity_eq_without_abs_of_neg_closed`: for a negation-closed class the
+  two complexities already agree.
 -/
 
 open Real Function MeasureTheory
@@ -254,3 +262,189 @@ lemma empiricalRademacherComplexity_without_abs_le_empiricalRademacherComplexity
   · intro x_1
     exact le_abs_self ((↑n)⁻¹ * ∑ k, ↑↑(i k) * f x_1 (S k))
   · simp
+
+/-- Empirical Rademacher complexity is nonnegative. -/
+lemma empiricalRademacherComplexity_nonneg
+    (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳) :
+    0 ≤ empiricalRademacherComplexity n f S := by
+  dsimp [empiricalRademacherComplexity]
+  apply mul_nonneg
+  · positivity
+  · apply Finset.sum_nonneg
+    intro σ _
+    exact Real.iSup_nonneg fun i ↦
+      abs_nonneg ((n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * f i (S k))
+
+/-- Pulling a function class back along a map is the same as mapping the sample. -/
+lemma empiricalRademacherComplexity_comp
+    {𝒴 : Type*} (g : ι → 𝒴 → ℝ) (q : 𝒳 → 𝒴) (S : Fin n → 𝒳) :
+    empiricalRademacherComplexity n (fun i x ↦ g i (q x)) S =
+      empiricalRademacherComplexity n g (q ∘ S) := by
+  rfl
+
+/-- Add a negative copy of every function in a class. -/
+def signSymmetrization (F : ι → 𝒳 → ℝ) : ι × Bool → 𝒳 → ℝ :=
+  fun ib x ↦ if ib.2 then F ib.1 x else -F ib.1 x
+
+/-- A function class is closed under pointwise negation. -/
+def IsNegClosed (F : ι → 𝒳 → ℝ) : Prop :=
+  ∀ i, ∃ j, F j = -F i
+
+private lemma abs_normalized_signed_sum_le
+    (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳)
+    (C : ℝ) (sC : 0 ≤ C) (hC : ∀ i j, |f i (S j)| ≤ C)
+    (σ : Signs n) (i : ι) :
+    |(n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * f i (S k)| ≤ C := by
+  by_cases hn : n = 0
+  · subst n
+    simpa using sC
+  have hn_pos : 0 < (n : ℝ) := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hn)
+  rw [abs_mul, abs_of_pos (inv_pos.mpr hn_pos)]
+  calc
+    (n : ℝ)⁻¹ * |∑ k : Fin n, (σ k : ℝ) * f i (S k)|
+        ≤ (n : ℝ)⁻¹ * ∑ k : Fin n, |(σ k : ℝ) * f i (S k)| := by
+          gcongr
+          exact Finset.abs_sum_le_sum_abs
+            (fun k : Fin n ↦ (σ k : ℝ) * f i (S k)) Finset.univ
+    _ = (n : ℝ)⁻¹ * ∑ k : Fin n, |f i (S k)| := by
+          congr 1
+          apply Finset.sum_congr rfl
+          intro k _
+          rw [abs_mul, abs_sigma, one_mul]
+    _ ≤ (n : ℝ)⁻¹ * ∑ _k : Fin n, C := by
+          gcongr with k
+          exact hC i k
+    _ = C := by
+          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+            nsmul_eq_mul]
+          field_simp
+
+/--
+Absolute empirical Rademacher complexity is the one-sided complexity of the
+class enlarged by pointwise negatives.
+-/
+lemma empiricalRademacherComplexity_eq_without_abs_signSymmetrization
+    [Nonempty ι] (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳)
+    (C : ℝ) (sC : 0 ≤ C) (hC : ∀ i j, |f i (S j)| ≤ C) :
+    empiricalRademacherComplexity n f S =
+      empiricalRademacherComplexity_without_abs n (signSymmetrization f) S := by
+  dsimp [empiricalRademacherComplexity, empiricalRademacherComplexity_without_abs]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro σ _
+  let A : ι → ℝ :=
+    fun i ↦ (n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * f i (S k)
+  have hrewrite :
+      (fun ib : ι × Bool ↦
+        (n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * signSymmetrization f ib (S k)) =
+        fun ib ↦ if ib.2 then A ib.1 else -A ib.1 := by
+    funext ib
+    rcases ib with ⟨i, b⟩
+    cases b <;> simp [signSymmetrization, A]
+  rw [hrewrite]
+  have hA : ∀ i, |A i| ≤ C :=
+    fun i ↦ abs_normalized_signed_sum_le n f S C sC hC σ i
+  have habs : BddAbove (Set.range fun i ↦ |A i|) :=
+    ⟨C, by rintro _ ⟨i, rfl⟩; exact hA i⟩
+  have hsym : BddAbove (Set.range fun ib : ι × Bool ↦
+      if ib.2 then A ib.1 else -A ib.1) := by
+    refine ⟨C, ?_⟩
+    rintro _ ⟨⟨i, b⟩, rfl⟩
+    cases b
+    · exact (neg_le_abs (A i)).trans (hA i)
+    · exact (le_abs_self (A i)).trans (hA i)
+  apply le_antisymm
+  · apply ciSup_le
+    intro i
+    rw [abs_eq_max_neg]
+    apply max_le
+    · simpa using
+        (le_ciSup hsym (i, true))
+    · simpa using
+        (le_ciSup hsym (i, false))
+  · apply ciSup_le
+    rintro ⟨i, b⟩
+    cases b
+    · exact (neg_le_abs (A i)).trans (le_ciSup habs i)
+    · exact (le_abs_self (A i)).trans (le_ciSup habs i)
+
+/--
+For a class closed under pointwise negation, absolute and one-sided empirical
+Rademacher complexity agree.
+-/
+lemma empiricalRademacherComplexity_eq_without_abs_of_neg_closed
+    [Nonempty ι] (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳)
+    (C : ℝ) (sC : 0 ≤ C) (hC : ∀ i j, |f i (S j)| ≤ C)
+    (hneg : IsNegClosed f) :
+    empiricalRademacherComplexity n f S =
+      empiricalRademacherComplexity_without_abs n f S := by
+  dsimp [empiricalRademacherComplexity, empiricalRademacherComplexity_without_abs]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro σ _
+  let A : ι → ℝ :=
+    fun i ↦ (n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * f i (S k)
+  have hA : ∀ i, |A i| ≤ C :=
+    fun i ↦ abs_normalized_signed_sum_le n f S C sC hC σ i
+  have habs : BddAbove (Set.range fun i ↦ |A i|) :=
+    ⟨C, by rintro _ ⟨i, rfl⟩; exact hA i⟩
+  have hplain : BddAbove (Set.range A) :=
+    ⟨C, by rintro _ ⟨i, rfl⟩; exact (le_abs_self (A i)).trans (hA i)⟩
+  change (⨆ i, |A i|) = ⨆ i, A i
+  apply le_antisymm
+  · apply ciSup_le
+    intro i
+    obtain ⟨j, hj⟩ := hneg i
+    have hAj : A j = -A i := by
+      dsimp only [A]
+      rw [hj]
+      simp only [Pi.neg_apply, mul_neg, Finset.sum_neg_distrib]
+    rw [abs_eq_max_neg]
+    apply max_le
+    · exact le_ciSup hplain i
+    · rw [← hAj]
+      exact le_ciSup hplain j
+  · apply ciSup_le
+    intro i
+    exact (le_abs_self (A i)).trans (le_ciSup habs i)
+
+-- Equip with the discrete sigma-algebra
+/--
+PMF-integral form of `empiricalRademacherFunctional`.
+-/
+noncomputable def empiricalRademacherFunctional_pmf
+    (φ : ℝ → ℝ) (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳) : ℝ :=
+  ∫ σ, ⨆ i, φ (normalizedRademacherSum n f S σ i) ∂𝙋
+
+/--
+The uniform finite average over sign vectors agrees with integration against
+the uniform sign-vector PMF, for every postprocessing function `φ`.
+-/
+lemma empiricalRademacherFunctional_eq_pmf
+    (φ : ℝ → ℝ) (f : ι → 𝒳 → ℝ) (S : Fin n → 𝒳) :
+    empiricalRademacherFunctional n φ f S =
+      empiricalRademacherFunctional_pmf n φ f S := by
+  dsimp [empiricalRademacherFunctional, empiricalRademacherFunctional_pmf]
+  set g : Signs n → ℝ :=
+    fun σ ↦ ⨆ i, φ (normalizedRademacherSum n f S σ i)
+  have htsum :
+      (∫ σ, g σ ∂𝙋) =
+        ∑' σ : Signs n, g σ * ((signVecPMF n) σ).toReal := by
+    rw [PMF.integral_eq_tsum]
+    · congr
+      ext σ
+      simp
+      exact CommMonoid.mul_comm ((signVecPMF n) σ).toReal (g σ)
+    · rw [← MeasureTheory.memLp_one_iff_integrable]
+      simp
+  have huniform :
+      ∑' σ : Signs n, g σ * ((signVecPMF n) σ).toReal =
+        (Fintype.card (Signs n) : ℝ)⁻¹ * ∑ σ : Signs n, g σ := by
+    simp [signVecPMF, PMF.uniformOfFintype_apply,
+      tsum_fintype, Finset.mul_sum, ENNReal.toReal_inv]
+    apply congrArg
+    ext σ
+    exact Eq.symm (CommMonoid.mul_comm (2 ^ n)⁻¹ (g σ))
+  change (Fintype.card (Signs n) : ℝ)⁻¹ * ∑ σ : Signs n, g σ = ∫ σ, g σ ∂𝙋
+  rw [htsum, huniform]
+


### PR DESCRIPTION
Thirteen declarations ported from `auto-res/lean-rademacher` at **`bc33376`**, appended
to two existing modules. No existing declaration is reordered, changed or removed.

## Why this is `02a` and not `02`

Appendix C-3's PR 02 covers four modules and measures **22 upstream declarations**
against the C-1 ceiling of 10–20. It splits at a boundary where both halves compile
independently:

- **02a (this PR)** — `Rademacher/Defs.lean` + `Rademacher/Signs.lean`, 13 declarations.
- **02b (next)** — `Rademacher/Complexity.lean` + `Probability/Concentration/McDiarmid.lean`,
  9 declarations. `Complexity.lean` consumes what this PR defines, so it stacks on top.

The halves are numbered `02a`/`02b` so C-3's cross-references to "02" stay valid.

## New declarations

`StatsMLlib/LearningTheory/Rademacher/Defs.lean`

| Declaration | |
|---|---|
| `normalizedRademacherSum` | `n⁻¹ * ∑ k, σ k * F h (S k)` for one hypothesis |
| `empiricalRademacherFunctional` | `\|Signs n\|⁻¹ * ∑ σ, ⨆ h, φ (normalizedRademacherSum …)` |
| `empiricalRademacherFunctional_abs` | `φ = abs` recovers `empiricalRademacherComplexity` |
| `empiricalRademacherFunctional_id` | `φ = id` recovers `empiricalRademacherComplexity_without_abs` |

The functional exists to state the absolute and one-sided complexities once instead of
twice. Both specialization lemmas hold by `rfl`, which is the check that the existing
StatsMLlib definitions are definitionally the upstream ones.

`StatsMLlib/LearningTheory/Rademacher/Signs.lean`

| Declaration | |
|---|---|
| `empiricalRademacherComplexity_nonneg` | nonnegativity |
| `empiricalRademacherComplexity_comp` | invariance under reindexing the hypothesis type |
| `signSymmetrization` | the class enlarged by pointwise negatives, indexed by `ι × Bool` |
| `IsNegClosed` | the class already contains the negative of each member |
| `abs_normalized_signed_sum_le` | `private`, used only by the two equalities below |
| `empiricalRademacherComplexity_eq_without_abs_signSymmetrization` | absolute complexity of `F` = one-sided complexity of `signSymmetrization F` |
| `empiricalRademacherComplexity_eq_without_abs_of_neg_closed` | for a negation-closed class the two agree |
| `empiricalRademacherFunctional_pmf` | the functional as a PMF integral |
| `empiricalRademacherFunctional_eq_pmf` | agreement of the two forms |

Sign symmetrization is what lets later results drop the absolute value: the price is
doubling the index type, and for a negation-closed class there is no price at all.

## Provenance against `bc33376`

| Module | verbatim | rewritten for v4.33 | upstream declarations left behind |
|---|---:|---:|---:|
| `Rademacher/Defs.lean` (with `UniformDeviation/Defs.lean`) | 8 | 3 | 0 |
| `Rademacher/Signs.lean` | 18 | 5 | 0 |

**Every one of the thirteen new declarations is byte-identical to its upstream original.**
The "rewritten" column counts declarations that already differed before this PR — pre-existing
StatsMLlib content, untouched here. `upstream-only = 0` on both files means nothing from
those upstream modules that belongs in them was left behind.

Upstream targets Lean v4.27.0-rc1 and this repository is on v4.33.0, so the zero is worth
stating plainly: 185 lines of upstream proof needed **no** version-diff repair. That
matches the calibration measured before starting the port (about one fix per 170 lines,
concentrated in `simp`-set and deprecated-name drift, neither of which these proofs hit).

## Verification

- `lake build` green across all 8800 jobs — every downstream module still builds
  (`Rademacher/Dudley`, `UniformDeviation/Bounds`, `LinearPredictor/L1`, `L2`,
  `Rademacher/Massart`).
- Both changed files re-elaborate with completely empty output: no warnings.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- Import direction unchanged; no new imports were needed in either module.
- 237 added lines, 13 declarations — inside the C-1 budget of 200–600 lines and 10–20
  declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
