### PR TITLE
Add expectation bounds for Rademacher complexity and iid McDiarmid corollaries

### DIFF
--- a/StatsMLlib/LearningTheory/Rademacher/Complexity.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Complexity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Kei Tsukamoto. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kei Tsukamoto, Kazumi Kasaura, Naoto Onda, Yuma Mizuno, Sho Sonoda
 -/
+import StatsMLlib.LearningTheory.Rademacher.Signs
 import StatsMLlib.LearningTheory.Rademacher.Symmetrization
 import StatsMLlib.Probability.Independence.FinsetPi
 import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
@@ -1391,4 +1392,111 @@ theorem expectation_le_rademacher {X : Ω → Z} [Nonempty ι] [Countable ι]
       apply Nat.cast_ne_zero.mpr hn
     _ = _ := by simp
 
+
+/-- A uniformly bounded class has empirical Rademacher complexity at most the same bound. -/
+theorem empiricalRademacherComplexity_le_of_bounded
+    {b : ℝ} (hb : 0 ≤ b) (hf' : ∀ (i : ι) (z : Z), |f i z| ≤ b)
+    (S : Fin n → Z) :
+    empiricalRademacherComplexity n f S ≤ b := by
+  by_cases hn : n = 0
+  · subst n
+    simpa [empiricalRademacherComplexity] using hb
+  dsimp [empiricalRademacherComplexity]
+  calc
+    (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ σ : Signs n, ⨆ i, |(n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * f i (S k)|
+        ≤ (Fintype.card (Signs n) : ℝ)⁻¹ * ∑ _σ : Signs n, b := by
+          apply mul_le_mul_of_nonneg_left
+          · apply Finset.sum_le_sum
+            intro σ _
+            apply Real.iSup_le
+            · intro i
+              rw [abs_mul, abs_of_nonneg (inv_nonneg.mpr (Nat.cast_nonneg n))]
+              calc
+                (n : ℝ)⁻¹ * |∑ k : Fin n, (σ k : ℝ) * f i (S k)|
+                    ≤ (n : ℝ)⁻¹ * ∑ k : Fin n, |(σ k : ℝ) * f i (S k)| := by
+                      gcongr
+                      exact Finset.abs_sum_le_sum_abs
+                        (fun k : Fin n ↦ (σ k : ℝ) * f i (S k)) Finset.univ
+                _ = (n : ℝ)⁻¹ * ∑ k : Fin n, |f i (S k)| := by
+                      congr 1
+                      apply Finset.sum_congr rfl
+                      intro k _
+                      rw [abs_mul, abs_sigma, one_mul]
+                _ ≤ (n : ℝ)⁻¹ * ∑ _k : Fin n, b := by
+                      gcongr with k
+                      exact hf' i (S k)
+                _ = b := by
+                      simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+                        nsmul_eq_mul]
+                      field_simp
+            · exact hb
+          · positivity
+    _ = b := by
+      simp
+
+/-- Measurability of empirical Rademacher complexity evaluated on a random sample. -/
+theorem measurable_empiricalRademacherComplexity_comp
+    [Countable ι] {X : Ω → Z} (hf : ∀ i, Measurable (f i ∘ X)) :
+    Measurable fun ω : Fin n → Ω ↦ empiricalRademacherComplexity n f (X ∘ ω) := by
+  dsimp only [empiricalRademacherComplexity]
+  apply Measurable.const_mul
+  apply Finset.univ.measurable_sum
+  intro σ _
+  apply Measurable.iSup
+  intro i
+  apply Measurable.abs
+  apply Measurable.const_mul
+  apply Finset.univ.measurable_sum
+  intro k _
+  apply measurable_const.mul
+  exact (hf i).comp (measurable_pi_apply k)
+
+/-- Integrability of empirical Rademacher complexity for a measurable uniformly bounded class. -/
+theorem integrable_empiricalRademacherComplexity_comp
+    [Countable ι] {X : Ω → Z} (hf : ∀ i, Measurable (f i ∘ X))
+    {b : ℝ} (hb : 0 ≤ b) (hf' : ∀ (i : ι) (z : Z), |f i z| ≤ b) :
+    Integrable (fun ω : Fin n → Ω ↦ empiricalRademacherComplexity n f (X ∘ ω)) μⁿ := by
+  rw [← memLp_one_iff_integrable]
+  apply MemLp.of_bound (measurable_empiricalRademacherComplexity_comp hf).aestronglyMeasurable b
+  filter_upwards with ω
+  rw [Real.norm_eq_abs, abs_of_nonneg (empiricalRademacherComplexity_nonneg n f (X ∘ ω))]
+  exact empiricalRademacherComplexity_le_of_bounded hb hf' (X ∘ ω)
+
+/-- An almost-everywhere empirical bound lifts to expected Rademacher complexity. -/
+theorem rademacherComplexity_le_of_ae_empirical_le
+    {X : Ω → Z} {C : ℝ}
+    (hint :
+      Integrable (fun ω : Fin n → Ω ↦ empiricalRademacherComplexity n f (X ∘ ω)) μⁿ)
+    (hC : ∀ᵐ ω : Fin n → Ω ∂μⁿ, empiricalRademacherComplexity n f (X ∘ ω) ≤ C) :
+    rademacherComplexity n f μ X ≤ C := by
+  rw [rademacherComplexity]
+  calc
+    μⁿ[fun ω : Fin n → Ω ↦ empiricalRademacherComplexity n f (X ∘ ω)]
+        ≤ μⁿ[fun _ω : Fin n → Ω ↦ C] :=
+      integral_mono_ae
+        (μ := μⁿ)
+        (f := fun ω : Fin n → Ω ↦ empiricalRademacherComplexity n f (X ∘ ω))
+        (g := fun _ω : Fin n → Ω ↦ C)
+        hint (integrable_const C) hC
+    _ = C := by simp
+
+/-- A bound valid for every fixed sample lifts to expected Rademacher complexity. -/
+theorem rademacherComplexity_le_of_empirical_le
+    {X : Ω → Z} {C : ℝ}
+    (hint :
+      Integrable (fun ω : Fin n → Ω ↦ empiricalRademacherComplexity n f (X ∘ ω)) μⁿ)
+    (hC : ∀ S : Fin n → Z, empiricalRademacherComplexity n f S ≤ C) :
+    rademacherComplexity n f μ X ≤ C :=
+  rademacherComplexity_le_of_ae_empirical_le hint
+    (Filter.Eventually.of_forall fun ω ↦ hC (X ∘ ω))
+
+/-- Countable measurable uniformly bounded classes need no separate integrability hypothesis. -/
+theorem rademacherComplexity_le_of_empirical_le_countable
+    [Countable ι] {X : Ω → Z} (hf : ∀ i, Measurable (f i ∘ X))
+    {b C : ℝ} (hb : 0 ≤ b) (hf' : ∀ (i : ι) (z : Z), |f i z| ≤ b)
+    (hC : ∀ S : Fin n → Z, empiricalRademacherComplexity n f S ≤ C) :
+    rademacherComplexity n f μ X ≤ C :=
+  rademacherComplexity_le_of_empirical_le
+    (integrable_empiricalRademacherComplexity_comp hf hb hf') hC
 end

--- a/StatsMLlib/Probability/Concentration/McDiarmid.lean
+++ b/StatsMLlib/Probability/Concentration/McDiarmid.lean
@@ -1073,3 +1073,60 @@ theorem mcdiarmid_inequality_pos'
   have hX : ∀ i, Measurable (X i) := fun i ↦ by measurability
   have hX' : iIndepFun X μⁿ := pi_comp_eval_iIndepFun hX''
   exact mcdiarmid_inequality_pos X hX hX' hfι hf'' hε ht'
+
+theorem mcdiarmid_inequality_neg'
+  {X' : Ω → 𝓧} (hX'' : Measurable X')
+  {f' : (ι → 𝓧) → ℝ}
+  {c' : ι → ℝ}
+  (hfι : ∀ (i : ι) (x : ι → 𝓧) (x' : 𝓧), |f' x - f' (Function.update x i x')| ≤ c' i)
+  (hf'' : Measurable f')
+  {ε : ℝ} (hε : ε ≥ 0)
+  {t : ℝ} (ht' : t * ∑ i, (c' i) ^ 2 ≤ 1) :
+  (μⁿ (fun ω : ι → Ω ↦ (f' (X' ∘ ω)) -
+    μⁿ[fun ω : ι → Ω ↦ f' (X' ∘ ω)] ≤ -ε)).toReal ≤
+    (-2 * ε ^ 2 * t).exp := by
+  let X : ι → (ι → Ω) → 𝓧 := fun i ω ↦ X' (ω i)
+  have hX : ∀ i, Measurable (X i) := fun i ↦ by measurability
+  have hX' : iIndepFun X μⁿ := pi_comp_eval_iIndepFun hX''
+  exact mcdiarmid_inequality_neg X hX hX' f' c' hfι hf'' _ hε _ ht'
+
+/--
+Upper-tail McDiarmid inequality for an i.i.d. sample when every coordinate
+has the same bounded-difference constant `c`.
+
+The hypothesis `t * |ι| * c^2 ≤ 1` is the constant-sensitivity form of
+`t * ∑ i, (c i)^2 ≤ 1`.
+-/
+theorem mcdiarmid_inequality_pos_iid_of_const
+  {X' : Ω → 𝓧} (hX : Measurable X')
+  {f' : (ι → 𝓧) → ℝ} {c : ℝ}
+  (hf : ∀ (i : ι) (x : ι → 𝓧) (x' : 𝓧),
+    |f' x - f' (Function.update x i x')| ≤ c)
+  (hf_meas : Measurable f')
+  {ε : ℝ} (hε : 0 ≤ ε)
+  {t : ℝ} (ht : t * (Fintype.card ι : ℝ) * c ^ 2 ≤ 1) :
+  (μⁿ (fun ω : ι → Ω ↦
+    f' (X' ∘ ω) - μⁿ[fun ω : ι → Ω ↦ f' (X' ∘ ω)] ≥ ε)).toReal ≤
+      (-2 * ε ^ 2 * t).exp := by
+  apply mcdiarmid_inequality_pos' hX hf hf_meas hε
+  simpa only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul,
+    mul_assoc] using ht
+
+/--
+Lower-tail McDiarmid inequality for an i.i.d. sample when every coordinate
+has the same bounded-difference constant `c`.
+-/
+theorem mcdiarmid_inequality_neg_iid_of_const
+  {X' : Ω → 𝓧} (hX : Measurable X')
+  {f' : (ι → 𝓧) → ℝ} {c : ℝ}
+  (hf : ∀ (i : ι) (x : ι → 𝓧) (x' : 𝓧),
+    |f' x - f' (Function.update x i x')| ≤ c)
+  (hf_meas : Measurable f')
+  {ε : ℝ} (hε : 0 ≤ ε)
+  {t : ℝ} (ht : t * (Fintype.card ι : ℝ) * c ^ 2 ≤ 1) :
+  (μⁿ (fun ω : ι → Ω ↦
+    f' (X' ∘ ω) - μⁿ[fun ω : ι → Ω ↦ f' (X' ∘ ω)] ≤ -ε)).toReal ≤
+      (-2 * ε ^ 2 * t).exp := by
+  apply mcdiarmid_inequality_neg' hX hf hf_meas hε
+  simpa only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul,
+    mul_assoc] using ht


### PR DESCRIPTION
Nine declarations ported from `auto-res/lean-rademacher` at **`bc33376`**, appended to
two existing modules. No existing declaration is reordered, changed or removed.

Second half of appendix C-3's PR 02; the first half is #10. Together they complete
that entry, which measures 22 upstream declarations against the C-1 ceiling of 20.

## New declarations

`StatsMLlib/LearningTheory/Rademacher/Complexity.lean` — the route from a fixed-sample
bound to a bound on the *expected* complexity:

| Declaration | |
|---|---|
| `empiricalRademacherComplexity_le_of_bounded` | a uniform bound on the class bounds the empirical complexity |
| `measurable_empiricalRademacherComplexity_comp` | measurability in the sample, for a countable index type |
| `integrable_empiricalRademacherComplexity_comp` | integrability, from measurability plus the uniform bound |
| `rademacherComplexity_le_of_ae_empirical_le` | transfer along an almost-everywhere bound |
| `rademacherComplexity_le_of_empirical_le` | transfer along a pointwise bound |
| `rademacherComplexity_le_of_empirical_le_countable` | the countable-class form |

`StatsMLlib/Probability/Concentration/McDiarmid.lean`:

| Declaration | |
|---|---|
| `mcdiarmid_inequality_neg'` | lower-tail form matching the existing `mcdiarmid_inequality_pos'` |
| `mcdiarmid_inequality_pos_iid_of_const` | iid upper tail with a constant difference bound |
| `mcdiarmid_inequality_neg_iid_of_const` | the lower-tail counterpart |

## One new import

`Complexity.lean` now imports `StatsMLlib.LearningTheory.Rademacher.Signs`. This
mirrors upstream, where `Rademacher/Expectation.lean` (which §0.3 maps onto
`Complexity.lean`) imports `Rademacher/Signs.lean`. `Signs` imports only `Defs` and
`Symmetrization`, so there is no cycle, and the import tier is unchanged.

## Provenance against `bc33376`

| Module | verbatim | rewritten for v4.33 | upstream declarations left behind |
|---|---:|---:|---:|
| `Rademacher/Complexity.lean` | 43 | 8 | 0 |
| `Probability/Concentration/McDiarmid.lean` | 20 | 8 | 0 |

`upstream-only = 0` on both: nothing from those upstream modules that belongs here was
left behind. The "rewritten" counts include declarations that already differed before
this PR — pre-existing StatsMLlib content, untouched here.

**Two of the nine new declarations needed a v4.33 repair**, both in
`measurable_empiricalRademacherComplexity_comp` and its neighbourhood.

1. `Function.comp_apply` no longer closes an unapplied composition:

```diff
-  simpa only [Function.comp_apply] using (hf i).comp (measurable_pi_apply k)
+  exact (hf i).comp (measurable_pi_apply k)
```

The goal is `Measurable fun a => f i (X (a k))` while the term has type
`Measurable ((f i ∘ X) ∘ fun a => a k)`. `Function.comp_apply` rewrites `(g ∘ h) a`,
but here the composition is never applied — it sits under `Measurable` as a function.
The two types are definitionally equal, so `exact` suffices.

2. A simp argument upstream passes is now flagged as unused:

```diff
-      simp [Signs.card]
+      simp
```

`linter.unusedSimpArgs` reports it, and `CONTRIBUTING.md` requires a warning-free
build.

## Verification

- `lake build` green across all 8800 jobs.
- Both changed files re-elaborate with completely empty output: no warnings.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- Import direction: no module imports from a later tier, including the new import.
- 165 added lines, 9 declarations — inside the C-1 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
