### PR TITLE
Add reindexing lemmas and the empirical complexity bounded-difference bound

### DIFF
--- a/FILE_TREE.md
+++ b/FILE_TREE.md
@@ -1,21 +1,21 @@
 # StatsMLlib file tree
 
 This document presents the public Lean source tree after the Mathlib-style subject refactor.
-`StatsMLlib/` contains 94 Lean modules under eight layer-one directories and no root-level Lean
+`StatsMLlib/` contains 95 Lean modules under eight layer-one directories and no root-level Lean
 files. A filesystem path such as `StatsMLlib/Probability/Process/Dudley.lean` corresponds to the Lean
 module `StatsMLlib.Probability.Process.Dudley`.
 
 | Layer | Modules |
 | --- | ---: |
 | `Analysis` | 5 |
-| `LearningTheory` | 13 |
+| `LearningTheory` | 14 |
 | `LinearAlgebra` | 5 |
 | `MeasureTheory` | 3 |
 | `Order` | 1 |
 | `Probability` | 44 |
 | `Statistics` | 21 |
 | `Topology` | 2 |
-| **Total** | **94** |
+| **Total** | **95** |
 
 ```text
 StatsMLlib/
@@ -41,6 +41,7 @@ StatsMLlib/
 │   │   ├── Defs.lean
 │   │   ├── Dudley.lean
 │   │   ├── Massart.lean
+│   │   ├── Reindex.lean
 │   │   ├── Signs.lean
 │   │   └── Symmetrization.lean
 │   └── UniformDeviation/

--- a/StatsMLlib/LearningTheory/Rademacher/Reindex.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Reindex.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import StatsMLlib.LearningTheory.Rademacher.Complexity
+import StatsMLlib.LearningTheory.UniformDeviation.Defs
+import StatsMLlib.Analysis.FiniteSample
+import StatsMLlib.Order.IndexedSupremum
+
+/-!
+# Reindexing function classes
+
+These lemmas distinguish a purely set-theoretic change of hypothesis index
+from the topological `denseRestriction` bridge.  Pulling a class back along
+an arbitrary map can only decrease empirical complexity; a surjective map
+does not change the class and hence preserves all three central quantities.
+-/
+
+open MeasureTheory
+
+universe u v w x
+
+section
+
+variable {n : ℕ}
+variable {Ω : Type u} [MeasurableSpace Ω]
+variable {H : Type v} {G : Type w} {𝒳 : Type x}
+
+/-- A surjective reindexing preserves the common empirical functional. -/
+theorem empiricalRademacherFunctional_reindex_eq_of_surjective
+    (φ : ℝ → ℝ) (F : H → 𝒳 → ℝ) (e : G → H)
+    (he : Function.Surjective e) (S : Fin n → 𝒳) :
+    empiricalRademacherFunctional n φ (fun g ↦ F (e g)) S =
+      empiricalRademacherFunctional n φ F S := by
+  dsimp [empiricalRademacherFunctional, normalizedRademacherSum]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro σ _
+  exact ciSup_comp_of_surjective e he
+    (fun h ↦ φ ((n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * F h (S k)))
+
+/--
+Pulling a uniformly bounded class back along an arbitrary index map can only
+decrease absolute empirical Rademacher complexity.
+-/
+theorem empiricalRademacherComplexity_reindex_le
+    [Nonempty G]
+    (F : H → 𝒳 → ℝ) (e : G → H) (S : Fin n → 𝒳)
+    {b : ℝ} (hb : 0 ≤ b) (hF : ∀ h x, |F h x| ≤ b) :
+    empiricalRademacherComplexity n (fun g ↦ F (e g)) S ≤
+      empiricalRademacherComplexity n F S := by
+  dsimp [empiricalRademacherComplexity]
+  apply mul_le_mul_of_nonneg_left
+  · apply Finset.sum_le_sum
+    intro σ _
+    have hbounded :
+        BddAbove (Set.range fun h ↦
+          |(n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * F h (S k)|) := by
+      refine ⟨b, ?_⟩
+      rintro _ ⟨h, rfl⟩
+      by_cases hn : n = 0
+      · subst n
+        simpa using hb
+      · apply abs_normalized_fin_sum_le (Nat.pos_of_ne_zero hn)
+          (fun k x ↦ (σ k : ℝ) * F h x) S
+        intro k x
+        simpa [abs_mul, abs_sigma] using hF h x
+    apply ciSup_le
+    intro g
+    exact le_ciSup hbounded (e g)
+  · positivity
+
+/-- A surjective reindexing preserves absolute empirical Rademacher complexity. -/
+theorem empiricalRademacherComplexity_reindex_eq_of_surjective
+    (F : H → 𝒳 → ℝ) (e : G → H)
+    (he : Function.Surjective e) (S : Fin n → 𝒳) :
+    empiricalRademacherComplexity n (fun g ↦ F (e g)) S =
+      empiricalRademacherComplexity n F S := by
+  simpa only [← empiricalRademacherFunctional_abs] using
+    empiricalRademacherFunctional_reindex_eq_of_surjective
+      (n := n) abs F e he S
+
+/-- A surjective reindexing preserves one-sided empirical Rademacher complexity. -/
+theorem empiricalRademacherComplexity_without_abs_reindex_eq_of_surjective
+    (F : H → 𝒳 → ℝ) (e : G → H)
+    (he : Function.Surjective e) (S : Fin n → 𝒳) :
+    empiricalRademacherComplexity_without_abs n (fun g ↦ F (e g)) S =
+      empiricalRademacherComplexity_without_abs n F S := by
+  simpa only [← empiricalRademacherFunctional_id] using
+    empiricalRademacherFunctional_reindex_eq_of_surjective
+      (n := n) id F e he S
+
+/-- A surjective hypothesis reindexing preserves expected Rademacher complexity. -/
+theorem rademacherComplexity_reindex_eq_of_surjective
+    (F : H → 𝒳 → ℝ) (e : G → H) (he : Function.Surjective e)
+    (μ : Measure Ω) (X : Ω → 𝒳) :
+    rademacherComplexity n (fun g ↦ F (e g)) μ X =
+      rademacherComplexity n F μ X := by
+  dsimp [rademacherComplexity]
+  apply integral_congr_ae
+  filter_upwards with S
+  exact empiricalRademacherComplexity_reindex_eq_of_surjective
+    (n := n) F e he (X ∘ S)
+
+/-- A surjective hypothesis reindexing preserves uniform deviation. -/
+theorem uniformDeviation_reindex_eq_of_surjective
+    (F : H → 𝒳 → ℝ) (e : G → H) (he : Function.Surjective e)
+    (μ : Measure Ω) (X : Ω → 𝒳) (S : Fin n → 𝒳) :
+    uniformDeviation n (fun g ↦ F (e g)) μ X S =
+      uniformDeviation n F μ X S := by
+  dsimp [uniformDeviation]
+  exact ciSup_comp_of_surjective e he
+    (fun h ↦
+      |(n : ℝ)⁻¹ * ∑ k : Fin n, F h (S k) -
+        ∫ x : Ω, F h (X x) ∂μ|)
+
+end

--- a/StatsMLlib/LearningTheory/UniformDeviation/BoundedDifference.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/BoundedDifference.lean
@@ -5,6 +5,8 @@ Authors: Kei Tsukamoto, Kazumi Kasaura, Naoto Onda, Yuma Mizuno, Sho Sonoda
 -/
 import StatsMLlib.LearningTheory.Rademacher.Complexity
 import StatsMLlib.LearningTheory.UniformDeviation.Defs
+import StatsMLlib.Analysis.FiniteSample
+import StatsMLlib.Order.IndexedSupremum
 
 /-!
 # Bounded Differences for Uniform Deviations
@@ -291,3 +293,76 @@ theorem uniformDeviation_measurable [Countable ι] [MeasurableSpace 𝒳]
     Measurable (uniformDeviation n f μ X) :=
   .iSup fun i ↦ ((measurable_const.mul (Finset.univ.measurable_sum fun j _ ↦
     (hf i).comp (measurable_pi_apply j))).add_const (-∫ (x : Ω), (fun ω' ↦ f i (X ω')) x ∂μ)).abs
+
+/--
+Replacing one observation changes absolute empirical Rademacher complexity by
+at most `2 * b / n` for a class bounded in absolute value by `b`.
+-/
+theorem empiricalRademacherComplexity_bounded_difference
+    [Nonempty ι]
+    (hn : 0 < n) {b : ℝ}
+    (hf' : ∀ i, ∀ z : 𝒳, |f i z| ≤ b)
+    (j : Fin n) (S : Fin n → 𝒳) (x' : 𝒳) :
+    |empiricalRademacherComplexity n f S -
+      empiricalRademacherComplexity n f (Function.update S j x')| ≤
+      (n : ℝ)⁻¹ * 2 * b := by
+  classical
+  let A (σ : Signs n) (i : ι) :=
+    (n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * f i (S k)
+  let B (σ : Signs n) (i : ι) :=
+    (n : ℝ)⁻¹ * ∑ k : Fin n,
+      (σ k : ℝ) * f i (Function.update S j x' k)
+  have hnorm :
+      ∀ (T : Fin n → 𝒳) (σ : Signs n) (i : ι),
+        |(n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * f i (T k)| ≤ b := by
+    intro T σ i
+    apply abs_normalized_fin_sum_le hn
+      (fun k x ↦ (σ k : ℝ) * f i x) T
+    intro k x
+    simpa [abs_mul, abs_sigma] using hf' i x
+  have hpoint :
+      ∀ (σ : Signs n) (i : ι),
+        |A σ i - B σ i| ≤ (n : ℝ)⁻¹ * 2 * b := by
+    intro σ i
+    exact abs_normalized_fin_sum_update_sub_le hn
+      (fun k x ↦ (σ k : ℝ) * f i x)
+      (fun k x ↦ by simpa [abs_mul, abs_sigma] using hf' i x)
+      j S x'
+  have hsup :
+      ∀ σ : Signs n,
+        |((⨆ i, |A σ i|) - (⨆ i, |B σ i|))| ≤
+          (n : ℝ)⁻¹ * 2 * b := by
+    intro σ
+    have hAbdd : BddAbove (Set.range fun i ↦ |A σ i|) :=
+      ⟨b, by
+        rintro _ ⟨i, rfl⟩
+        exact hnorm S σ i⟩
+    have hBbdd : BddAbove (Set.range fun i ↦ |B σ i|) :=
+      ⟨b, by
+        rintro _ ⟨i, rfl⟩
+        exact hnorm (Function.update S j x') σ i⟩
+    exact abs_ciSup_sub_ciSup_le hAbdd hBbdd fun i ↦
+      (abs_abs_sub_abs_le_abs_sub (A σ i) (B σ i)).trans (hpoint σ i)
+  dsimp only [empiricalRademacherComplexity]
+  rw [← mul_sub, ← Finset.sum_sub_distrib, abs_mul]
+  have hcard : 0 < (Fintype.card (Signs n) : ℝ) := by
+    rw [Signs.card]
+    positivity
+  rw [abs_of_pos (inv_pos.mpr hcard)]
+  calc
+    (Fintype.card (Signs n) : ℝ)⁻¹ *
+        |∑ σ : Signs n,
+          ((⨆ i, |A σ i|) - (⨆ i, |B σ i|))|
+        ≤ (Fintype.card (Signs n) : ℝ)⁻¹ *
+            ∑ σ : Signs n,
+              |((⨆ i, |A σ i|) - (⨆ i, |B σ i|))| := by
+          gcongr
+          exact Finset.abs_sum_le_sum_abs
+            (fun σ : Signs n ↦ (⨆ i, |A σ i|) - (⨆ i, |B σ i|)) Finset.univ
+    _ ≤ (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ _σ : Signs n, ((n : ℝ)⁻¹ * 2 * b) := by
+          gcongr with σ
+          exact hsup σ
+    _ = (n : ℝ)⁻¹ * 2 * b := by simp
+
+end


### PR DESCRIPTION
Seven declarations ported from `auto-res/lean-rademacher` at **`bc33376`**. Pure
additions: no existing declaration is changed, reordered or removed.

## Why this is `03a`

Appendix C-3's PR 03 bundles a new module with the §14.5 refactor of an existing
proof. C-1 forbids exactly that combination:

> **追加と、既存の動いている証明のリファクタを混ぜない。** リファクタを含む PR には
> 「宣言の追加・削除ゼロ」と明記する。

So it splits:

- **03a (this PR)** — the additions. Seven declarations, nothing existing touched.
- **03b (next, stacked on this)** — the refactor. Rewrites the existing
  `uniformDeviation_bounded_difference` through the factored lemmas, with **zero
  declarations added or removed**.

Reviewing them separately means 03a can be read as a straight port, and 03b's diff
contains only the proof being changed.

## New declarations

`StatsMLlib/LearningTheory/Rademacher/Reindex.lean` (new module):

| Declaration | |
|---|---|
| `empiricalRademacherFunctional_reindex_eq_of_surjective` | the sign functional is unchanged along a surjection |
| `empiricalRademacherComplexity_reindex_le` | pulling back along an arbitrary map can only decrease complexity |
| `empiricalRademacherComplexity_reindex_eq_of_surjective` | along a surjection it is unchanged |
| `empiricalRademacherComplexity_without_abs_reindex_eq_of_surjective` | the one-sided version |
| `rademacherComplexity_reindex_eq_of_surjective` | the expected complexity |
| `uniformDeviation_reindex_eq_of_surjective` | uniform deviation |

The point of the module is to keep a purely set-theoretic change of hypothesis index
distinct from the topological `denseRestriction` bridge that arrives later: a
surjection does not change the class, so all three central quantities are preserved.

`StatsMLlib/LearningTheory/UniformDeviation/BoundedDifference.lean`:

| Declaration | |
|---|---|
| `empiricalRademacherComplexity_bounded_difference` | replacing one sample point moves the empirical complexity by at most `2b/n` |

## §14.5 was already two-thirds done

Plan §14.5 has three items. The first two — the `iSup` distance lemma in
`Order/IndexedSupremum.lean` and the one-sample-replacement estimate in
`Analysis/FiniteSample.lean` — both landed in PR 01 (`abs_ciSup_sub_ciSup_le`,
`abs_normalized_fin_sum_update_sub_le`). Only the third item, restating the two
bounded-difference results through them, is left, and this PR does the half of it that
is an addition. Upstream already states
`empiricalRademacherComplexity_bounded_difference` in the factored form, so it arrives
that way for free.

## Two imports added

`BoundedDifference.lean` now also imports `StatsMLlib.Analysis.FiniteSample` and
`StatsMLlib.Order.IndexedSupremum` — required by the factored statement, and matching
upstream's own import list for the same module. Import tier is unchanged.

## Provenance against `bc33376`

All seven new declarations are byte-identical to their upstream originals. Neither
module has any upstream declaration left behind.

**No v4.33 repair was needed.** The only edits to upstream text were the import lines,
rewritten mechanically through the §0.3 mapping.

## Verification

- `lake build` green across all 8800 jobs.
- Both changed files re-elaborate with completely empty output: no warnings.
- `import StatsMLlib.LearningTheory.Rademacher.Reindex` type-checks standalone.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- `FILE_TREE.md` counts cross-checked against the real tree: 95 modules, `LearningTheory` 14.
- 193 added lines, 7 declarations — inside the C-1 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
