### PR TITLE
Restate the uniform-deviation bounded difference through the factored lemmas

### DIFF
--- a/StatsMLlib/LearningTheory/UniformDeviation/BoundedDifference.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/BoundedDifference.lean
@@ -36,258 +36,74 @@ variable {n : ℕ} {ι : Type v} {f : ι → 𝒳 → ℝ} {μ : Measure Ω}
 
 local notation "μⁿ" => Measure.pi (fun _ ↦ μ)
 
+/--
+Replacing one observation changes uniform deviation by at most `2 * b / n`
+for a function class bounded in absolute value by `b`.
+-/
 theorem uniformDeviation_bounded_difference [Nonempty ι] [IsProbabilityMeasure μ]
     (hn : 0 < n) (X : Ω → 𝒳)
     (hf : ∀ i, Measurable (f i ∘ X))
-    {b : ℝ} (hb : 0 ≤ b)
-    (hf': ∀ i, ∀ z : 𝒳, |f i z| ≤ b)
+    {b : ℝ} (hf' : ∀ i, ∀ z : 𝒳, |f i z| ≤ b)
     (i : Fin n) (S : Fin n → 𝒳) (x' : 𝒳) :
-    |uniformDeviation n f μ X S - uniformDeviation n f μ X (Function.update S i x')| ≤
+    |uniformDeviation n f μ X S -
+      uniformDeviation n f μ X (Function.update S i x')| ≤
       (n : ℝ)⁻¹ * 2 * b := by
-  dsimp [uniformDeviation]
-  let g (i : ι) := (↑n)⁻¹ * ∑ k : Fin n, f i (S k) - ∫ (x : Ω), f i (X x) ∂μ
-  let h (i_1 : ι) := (↑n)⁻¹ * ∑ k : Fin n, f i_1 (Function.update S i x' k) - ∫ (x : Ω), f i_1 (X x) ∂μ
-  have s' : ∀ (a : ι), |∫ (x : Ω), f a (X x) ∂μ| ≤ b := by
-    intro a
+  let g (h : ι) :=
+    (n : ℝ)⁻¹ * ∑ k : Fin n, f h (S k) -
+      ∫ x : Ω, f h (X x) ∂μ
+  let g' (h : ι) :=
+    (n : ℝ)⁻¹ * ∑ k : Fin n, f h (Function.update S i x' k) -
+      ∫ x : Ω, f h (X x) ∂μ
+  have hmean : ∀ h, |∫ x : Ω, f h (X x) ∂μ| ≤ b := by
+    intro h
     calc
-    _ ≤ ∫ (x : Ω), |f a (X x)| ∂μ := abs_integral_le_integral_abs
-    _ ≤ ∫ (x : Ω), b ∂μ := by
-      apply integral_mono
-      · constructor
-        · apply Measurable.aestronglyMeasurable
-          exact Measurable.comp measurable_abs (hf a)
-        · apply HasFiniteIntegral.of_mem_Icc
-          filter_upwards
-          intro a_1
-          constructor
-          · exact abs_nonneg (f a (X a_1))
-          · apply hf'
-      · exact integrable_const b
-      exact fun i ↦ hf' a (X i)
-    _ = b := by simp
-  have p''' : ∀ j, |g j - h j| ≤ (↑n)⁻¹ * 2 * b := by
-    intro j
+      |∫ x : Ω, f h (X x) ∂μ| ≤ ∫ x : Ω, |f h (X x)| ∂μ :=
+        abs_integral_le_integral_abs
+      _ ≤ ∫ _x : Ω, b ∂μ := by
+        apply integral_mono
+        · constructor
+          · exact (measurable_abs.comp (hf h)).aestronglyMeasurable
+          · apply HasFiniteIntegral.of_mem_Icc
+            filter_upwards
+            intro x
+            exact ⟨abs_nonneg _, hf' h (X x)⟩
+        · exact integrable_const b
+        · exact fun x ↦ hf' h (X x)
+      _ = b := by simp
+  have hsample :
+      ∀ (T : Fin n → 𝒳) (h : ι),
+        |(n : ℝ)⁻¹ * ∑ k : Fin n, f h (T k)| ≤ b := by
+    intro T h
+    exact abs_normalized_fin_sum_le hn (fun _ x ↦ f h x) T
+      (fun _ x ↦ hf' h x)
+  have hpoint : ∀ h, |g h - g' h| ≤ (n : ℝ)⁻¹ * 2 * b := by
+    intro h
+    dsimp only [g, g']
+    rw [sub_sub_sub_cancel_right]
+    exact abs_normalized_fin_sum_update_sub_le hn
+      (fun _ x ↦ f h x) (fun _ x ↦ hf' h x) i S x'
+  have hg : BddAbove (Set.range fun h ↦ |g h|) := by
+    refine ⟨b + b, ?_⟩
+    rintro _ ⟨h, rfl⟩
     calc
-    _ = |(↑n)⁻¹ * ∑ k : Fin n, f j (S k) - (↑n)⁻¹ * ∑ k : Fin n, f j (Function.update S i x' k)| := by
-      dsimp [g, h]
-      rw [sub_sub_sub_cancel_right]
-    _ = |(↑n)⁻¹ * (∑ k : Fin n, f j (S k) - ∑ k : Fin n, f j (Function.update S i x' k))| := by
-      apply congrArg
-      exact
-        Eq.symm
-          (mul_sub_left_distrib (↑n)⁻¹ (∑ k : Fin n, f j (S k))
-            (∑ k : Fin n, f j (Function.update S i x' k)))
-    _ = |(↑n)⁻¹ * (∑ k : Fin n, (f j (S k) - f j (Function.update S i x' k)))| := by
-      apply congrArg
-      rw [Finset.sum_sub_distrib]
-    _ = (↑n)⁻¹ * |(∑ k : Fin n, (f j (S k) - f j (Function.update S i x' k)))| := by
-      rw [abs_mul]
-      simp
-    _ ≤ (↑n)⁻¹ * 2 * b := by
-      refine (inv_mul_le_iff₀' ?_).mpr ?_
-      exact Nat.cast_pos'.mpr hn
-      have pe : (↑n)⁻¹ * 2 * b * ↑n = 2 * b := by
-        field_simp
-      rw [pe]
-      trans ∑ k : Fin n, |(f j (S k) - f j (Function.update S i x' k))|
-      · exact
-        Finset.abs_sum_le_sum_abs (fun i_1 ↦ f j (S i_1) - f j (Function.update S i x' i_1))
-          Finset.univ
-      · calc
-        _ = ∑ k : Fin n, |if i = k then f j (S k) - f j x' else 0| := by
-          apply congrArg
-          ext k
-          apply congrArg
-          dsimp [Function.update]
-          simp only [eq_rec_constant, dite_eq_ite]
-          have t : f j (S k) - f j (if k = i then x' else S k) = if i = k then f j (S k) - f j x' else 0 := by
-            calc
-            _ = f j (S k) - (if k = i then f j x' else f j (S k)) := by
-              simp only [sub_right_inj]
-              exact apply_ite (f j) (k = i) x' (S k)
-            _ = (if k = i then f j (S k) - f j x' else f j (S k) - f j (S k)) := by
-              exact sub_ite (k = i) (f j (S k)) (f j x') (f j (S k))
-            _ = _ := by
-              simp only [sub_self]
-              refine Eq.symm (if_congr ?_ rfl rfl)
-              exact eq_comm
-          exact t
-        _ = ∑ k : Fin n, if i = k then |f j (S k) - f j x'| else |0| := by
-          apply congrArg
-          ext k
-          exact apply_ite abs (i = k) (f j (S k) - f j x') 0
-        _ = |f j (S i) - f j x'| := by simp
-        _ ≤ |f j (S i)| + |f j x'| := abs_sub (f j (S i)) (f j x')
-        _ ≤ b + b := add_le_add (hf' j (S i)) (hf' j x')
-        _ = 2 * b := by ring
-  suffices |(⨆ (i : ι), (|g i|)) - ⨆ (i_1 : ι), (|h i_1|)| ≤ (↑n)⁻¹ * 2 * b from by
-    exact this
-  have p : (⨆ i, |g i|) - ⨆ i_1, |h i_1| ≤ (↑n)⁻¹ * 2 * b := by
-    have p0 : (⨆ i, |g i|) - ⨆ i_1, |h i_1| = ⨆ i, |g i| - ⨆ i_1, |h i_1| := by
-      apply ciSup_sub
-      rw [bddAbove_def]
-      use b + b
-      simp only [Set.mem_range, forall_exists_index, forall_apply_eq_imp_iff]
-      intro a
-      have s : |(↑n)⁻¹ * ∑ k : Fin n, f a (S k)| ≤ b := by
-        calc
-        _ = (↑n)⁻¹ * |∑ k : Fin n, f a (S k)| := by
-          rw [abs_mul]
-          simp
-        _ ≤ (↑n)⁻¹ * ∑ k : Fin n, |f a (S k)| := by
-          refine mul_le_mul_of_nonneg ?_ ?_ ?_ ?_
-          apply Preorder.le_refl
-          exact Finset.abs_sum_le_sum_abs (fun i ↦ f a (S i)) Finset.univ
-          simp
-          refine Fintype.sum_nonneg ?_
-          refine Pi.le_def.mpr ?_
-          intro i
-          simp
-        _ ≤ (↑n)⁻¹ * ∑ k : Fin n, b := by
-          refine mul_le_mul_of_nonneg ?_ ?_ ?_ ?_
-          apply Preorder.le_refl
-          exact Finset.sum_le_sum fun i a_1 ↦ hf' a (S i)
-          simp only [inv_nonneg, Nat.cast_nonneg]
-          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-          simp only [Nat.cast_pos, mul_nonneg_iff_of_pos_left, hn, hb]
-        _ = b := by
-          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-          field_simp
-      trans |(↑n)⁻¹ * ∑ k : Fin n, f a (S k)| + |∫ (x : Ω), f a (X x) ∂μ|
-      · exact abs_sub ((↑n)⁻¹ * ∑ k : Fin n, f a (S k)) (∫ (x : Ω), f a (X x) ∂μ)
-      · exact add_le_add s (s' a)
-    rw [p0]
-    refine Real.iSup_le ?_ ?_
-    intro j
-    have p' : |g j| - ⨆ i_1, |h i_1| ≤ |g j| - |h j| := by
-      refine tsub_le_tsub_left ?_ |g j|
-      suffices (abs ∘ h) j ≤ ⨆ i_1, (abs ∘ h) i_1 from by
-        exact this
-      apply le_ciSup
-      rw [bddAbove_def]
-      use b + b
-      intro y
-      simp only [Set.mem_range, Function.comp_apply, forall_exists_index]
-      intro z hx
-      rw [<- hx]
-      have s0 : |(↑n)⁻¹ * ∑ k : Fin n, f z (Function.update S i x' k)| ≤ b := by
-        calc
-        _ = (↑n)⁻¹ * |∑ k : Fin n, f z (Function.update S i x' k)| := by
-          rw [abs_mul]
-          simp
-        _ ≤ (↑n)⁻¹ * ∑ k : Fin n, |f z (Function.update S i x' k)| := by
-          refine mul_le_mul_of_nonneg ?_ ?_ ?_ ?_
-          apply Preorder.le_refl
-          exact Finset.abs_sum_le_sum_abs (fun i_1 ↦ f z (Function.update S i x' i_1)) Finset.univ
-          simp only [inv_nonneg, Nat.cast_nonneg]
-          refine Fintype.sum_nonneg ?_
-          refine Pi.le_def.mpr ?_
-          intro i
-          simp
-        _ ≤ (↑n)⁻¹ * ∑ k : Fin n, b := by
-          refine mul_le_mul_of_nonneg ?_ ?_ ?_ ?_
-          apply Preorder.le_refl
-          exact Finset.sum_le_sum fun i_1 a ↦ hf' z (Function.update S i x' i_1)
-          simp only [inv_nonneg, Nat.cast_nonneg]
-          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-          simp only [Nat.cast_pos, mul_nonneg_iff_of_pos_left, hn, hb]
-        _ = b := by
-          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-          field_simp
-      trans |(↑n)⁻¹ * ∑ k : Fin n, f z (Function.update S i x' k)| + |∫ (x : Ω), f z (X x) ∂μ|
-      · exact
-        abs_sub ((↑n)⁻¹ * ∑ k : Fin n, f z (Function.update S i x' k)) (∫ (x : Ω), f z (X x) ∂μ)
-      · exact add_le_add s0 (s' z)
-    have p'' : |g j| - |h j| ≤ |g j - h j| := abs_sub_abs_le_abs_sub (g j) (h j)
-    have p1 := p''' j
-    linarith
-    apply (mul_nonneg_iff_of_pos_left _).mpr hb
-    apply Left.mul_pos (inv_pos_of_pos (Nat.cast_pos.mpr hn)) (by linarith)
-  have p' : (⨆ i_1, |h i_1|) - ⨆ i, |g i| ≤ (↑n)⁻¹ * 2 * b := by
-    have p0 : (⨆ i_1, |h i_1|) - ⨆ i, |g i| = ⨆ i_1, |h i_1| - ⨆ i, |g i| := by
-      apply ciSup_sub
-      rw [bddAbove_def]
-      use b + b
-      simp only [Set.mem_range, forall_exists_index, forall_apply_eq_imp_iff]
-      intro z
-      have s0 : |(↑n)⁻¹ * ∑ k : Fin n, f z (Function.update S i x' k)| ≤ b := by
-        calc
-        _ = (↑n)⁻¹ * |∑ k : Fin n, f z (Function.update S i x' k)| := by
-          rw [abs_mul]
-          simp
-        _ ≤ (↑n)⁻¹ * ∑ k : Fin n, |f z (Function.update S i x' k)| := by
-          refine mul_le_mul_of_nonneg ?_ ?_ ?_ ?_
-          apply Preorder.le_refl
-          exact Finset.abs_sum_le_sum_abs (fun i_1 ↦ f z (Function.update S i x' i_1)) Finset.univ
-          simp only [inv_nonneg, Nat.cast_nonneg]
-          refine Fintype.sum_nonneg ?_
-          refine Pi.le_def.mpr ?_
-          intro i
-          simp
-        _ ≤ (↑n)⁻¹ * ∑ k : Fin n, b := by
-          refine mul_le_mul_of_nonneg ?_ ?_ ?_ ?_
-          apply Preorder.le_refl
-          exact Finset.sum_le_sum fun i_1 a ↦ hf' z (Function.update S i x' i_1)
-          simp only [inv_nonneg, Nat.cast_nonneg]
-          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-          simp only [Nat.cast_pos, mul_nonneg_iff_of_pos_left, hn, hb]
-        _ = b := by
-          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-          field_simp
-      trans |(↑n)⁻¹ * ∑ k : Fin n, f z (Function.update S i x' k)| + |∫ (x : Ω), f z (X x) ∂μ|
-      · exact abs_sub ((↑n)⁻¹ * ∑ k : Fin n, f z (Function.update S i x' k)) (∫ (x : Ω), f z (X x) ∂μ)
-      · exact add_le_add s0 (s' z)
-    rw [p0]
-    refine Real.iSup_le ?_ ?_
-    intro j
-    have p' : |h j| - ⨆ i_1, |g i_1| ≤ |h j| - |g j| := by
-      refine tsub_le_tsub_left ?_ |h j|
-      suffices (abs ∘ g) j ≤ ⨆ i_1, (abs ∘ g) i_1 from by
-        exact this
-      apply le_ciSup
-      rw [bddAbove_def]
-      use b + b
-      intro y
-      simp only [Set.mem_range, Function.comp_apply, forall_exists_index]
-      intro z hx
-      rw [<- hx]
-      have s : |(↑n)⁻¹ * ∑ k : Fin n, f z (S k)| ≤ b := by
-        calc
-        _ = (↑n)⁻¹ * |∑ k : Fin n, f z (S k)| := by
-          rw [abs_mul]
-          simp
-        _ ≤ (↑n)⁻¹ * ∑ k : Fin n, |f z (S k)| := by
-          refine mul_le_mul_of_nonneg ?_ ?_ ?_ ?_
-          apply Preorder.le_refl
-          exact Finset.abs_sum_le_sum_abs (fun i ↦ f z (S i)) Finset.univ
-          simp only [inv_nonneg, Nat.cast_nonneg]
-          refine Fintype.sum_nonneg ?_
-          refine Pi.le_def.mpr ?_
-          intro i
-          simp
-        _ ≤ (↑n)⁻¹ * ∑ k : Fin n, b := by
-          refine mul_le_mul_of_nonneg ?_ ?_ ?_ ?_
-          apply Preorder.le_refl
-          exact Finset.sum_le_sum fun i a_1 ↦ hf' z (S i)
-          simp only [inv_nonneg, Nat.cast_nonneg]
-          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-          simp only [Nat.cast_pos, mul_nonneg_iff_of_pos_left, hn, hb]
-        _ = b := by
-          simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-          field_simp
-      trans |(↑n)⁻¹ * ∑ k : Fin n, f z (S k)| + |∫ (x : Ω), f z (X x) ∂μ|
-      · exact abs_sub ((↑n)⁻¹ * ∑ k : Fin n, f z (S k)) (∫ (x : Ω), f z (X x) ∂μ)
-      · apply add_le_add s (s' z)
-    have p'' : |h j| - |g j| ≤ |h j - g j| := abs_sub_abs_le_abs_sub (h j) (g j)
-    have p1 : |h j - g j| ≤ (↑n)⁻¹ * 2 * b := by
-      calc
-      _ = |g j - h j| := abs_sub_comm (h j) (g j)
-      _ ≤ (↑n)⁻¹ * 2 * b := p''' j
-    linarith
-    apply Left.mul_nonneg _ hb
-    apply Left.mul_nonneg (inv_nonneg_of_nonneg (Nat.cast_nonneg n)) (by linarith)
-  apply abs_sub_le_iff.mpr ⟨p, p'⟩
-
+      |g h| ≤
+          |(n : ℝ)⁻¹ * ∑ k : Fin n, f h (S k)| +
+            |∫ x : Ω, f h (X x) ∂μ| := by
+              exact abs_sub _ _
+      _ ≤ b + b := add_le_add (hsample S h) (hmean h)
+  have hg' : BddAbove (Set.range fun h ↦ |g' h|) := by
+    refine ⟨b + b, ?_⟩
+    rintro _ ⟨h, rfl⟩
+    calc
+      |g' h| ≤
+          |(n : ℝ)⁻¹ * ∑ k : Fin n, f h (Function.update S i x' k)| +
+            |∫ x : Ω, f h (X x) ∂μ| := by
+              exact abs_sub _ _
+      _ ≤ b + b :=
+        add_le_add (hsample (Function.update S i x') h) (hmean h)
+  dsimp only [uniformDeviation]
+  exact abs_ciSup_sub_ciSup_le hg hg' fun h ↦
+    (abs_abs_sub_abs_le_abs_sub (g h) (g' h)).trans (hpoint h)
 theorem uniformDeviation_measurable [Countable ι] [MeasurableSpace 𝒳]
     (X : Ω → 𝒳) (hf : ∀ i, Measurable (f i)) :
     Measurable (uniformDeviation n f μ X) :=

--- a/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
@@ -71,7 +71,7 @@ theorem uniform_deviation_mcdiarmid_tail
     [IsProbabilityMeasure μ]
     {X : Ω → 𝒳} (hX : Measurable X)
     (hf : ∀ i, Measurable (f i))
-    {b : ℝ} (hb : 0 ≤ b) (hf': ∀ i x, |f i x| ≤ b)
+    {b : ℝ} (hf': ∀ i x, |f i x| ≤ b)
     {t : ℝ} (ht' : t * b ^ 2 ≤ 1 / 2)
     {ε : ℝ} (hε : 0 ≤ ε) :
     (μⁿ (fun ω : Fin n → Ω ↦ uniformDeviation n f μ X (X ∘ ω) -
@@ -95,7 +95,7 @@ theorem uniform_deviation_mcdiarmid_tail
   have hfX : ∀ i, Measurable (f i ∘ X) := fun i => (hf i).comp hX
   calc
     _ ≤ (-2 * ε ^ 2 * (n * t / 2)).exp :=
-      mcdiarmid_inequality_pos' hX (uniformDeviation_bounded_difference hn X hfX hb hf')
+      mcdiarmid_inequality_pos' hX (uniformDeviation_bounded_difference hn X hfX hf')
         (uniformDeviation_measurable X hf) hε ht'
     _ = _ := congr_arg _ (by ring)
 
@@ -115,7 +115,7 @@ theorem uniform_deviation_tail_bound_countable
     change μⁿ.real _ ≤ 1
     exact measureReal_le_one
   have hn : 0 < n := Nat.pos_of_ne_zero hn
-  apply le_trans _ (uniform_deviation_mcdiarmid_tail (μ := μ) hX hf hb hf' ht' hε)
+  apply le_trans _ (uniform_deviation_mcdiarmid_tail (μ := μ) hX hf hf' ht' hε)
   apply ENNReal.toReal_mono (measure_ne_top _ _)
   apply measure_mono
   intro ω h


### PR DESCRIPTION
**Refactor only. Zero declarations added or removed.** Plan §14.5.

Stacked on #12 — review that first; GitHub will retarget this to `main` when #12 merges.

## What changed

`uniformDeviation_bounded_difference` inlined the same argument twice: a `ciSup_sub`
step, a `BddAbove` witness built by hand, and a pointwise bound on the normalized
sample mean — once for the sample `S` and once for the one-point update
`Function.update S i x'`. Lines `:125–164` and `:206–245` were near-identical.

Both are now the lemmas PR 01 added:

- `abs_normalized_fin_sum_le` (`Analysis/FiniteSample.lean`)
- `abs_normalized_fin_sum_update_sub_le` (same)
- `abs_ciSup_sub_ciSup_le` (`Order/IndexedSupremum.lean`)

**253 lines → 69**, which is exactly the upstream statement of the same theorem at
`bc33376`. §14.5's other two items — adding those lemmas — landed in PR 01, so this
completes the section.

Declarations before and after are the same three:
`uniformDeviation_bounded_difference`, `uniformDeviation_measurable`,
`empiricalRademacherComplexity_bounded_difference`.

## The signature change

`hb : 0 ≤ b` is dropped, as upstream dropped it.

It is redundant. `0 < n` supplies a sample point, and `|f i (S k)| ≤ b` with a
nonnegative left-hand side forces `0 ≤ b`. Removing a hypothesis weakens the
statement, so every existing use stays valid once the argument is deleted — this is a
strengthening, not a break.

There was exactly one call site, in `UniformDeviation/Bounds.lean`.

## One forced consequence

Dropping `hb` leaves it unused in `uniform_deviation_mcdiarmid_tail`. `CONTRIBUTING.md`
says to remove unused parameters rather than hide them behind `_`, and the build must
be warning-free, so it is removed there too. Upstream's version of that theorem also
has no `hb`, so this anticipates by one step what PR 05 would do when it ports
`Generalization/Countable.lean` onto this module.

The cascade stops there: `uniform_deviation_tail_bound_countable` still uses its own
`hb`, at the call to
`uniform_deviation_expectation_le_two_smul_rademacher_complexity`.

## Why this is a separate PR from #12

C-1:

> **追加と、既存の動いている証明のリファクタを混ぜない。** リファクタを含む PR には
> 「宣言の追加・削除ゼロ」と明記する。

C-3's PR 03 bundles both. #12 carries the additions; this carries the refactor, and
its diff is only the proof being replaced plus the two-line consequence above.

## Verification

- `lake build` green across all 8800 jobs.
- Both changed files re-elaborate with completely empty output: no warnings, and in
  particular no unused-variable warning anywhere in the cascade.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- Declaration list of `BoundedDifference.lean` unchanged, checked mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
