### PR TITLE
Add empirical pseudometric lemmas and the empirical function space instances

### DIFF
--- a/StatsMLlib/LearningTheory/EmpiricalProcess/FunctionClass.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalProcess/FunctionClass.lean
@@ -5,6 +5,7 @@ Authors: Kei Tsukamoto, Kazumi Kasaura, Naoto Onda, Yuma Mizuno, Sho Sonoda
 -/
 import StatsMLlib.LearningTheory.EmpiricalProcess.Metric
 import StatsMLlib.Topology.MetricSpace.CoveringNumber.Basic
+import StatsMLlib.Analysis.FiniteSample
 
 /-!
 # Empirical Pseudo-Metric Spaces
@@ -101,4 +102,96 @@ noncomputable instance : Dist (EmpiricalFunctionSpace F S) where
 noncomputable instance : PseudoMetricSpace (EmpiricalFunctionSpace F S) :=
   PseudoMetricSpace.induced (fun f ↦ F f.index) (empiricalPMet S)
 
+
+@[simp]
+lemma empiricalNorm_neg (S : Fin n → 𝒳) (f : 𝒳 → ℝ) :
+    empiricalNorm S (-f) = empiricalNorm S f := by
+  simp [empiricalNorm, EmpiricalProcess.empiricalNorm]
+
+@[simp]
+lemma empiricalDist_neg_neg (S : Fin n → 𝒳) (f g : 𝒳 → ℝ) :
+    empiricalDist S (-f) (-g) = empiricalDist S f g := by
+  rw [empiricalDist, empiricalDist]
+  have h : (-f) - (-g) = -(f - g) := by
+    ext x
+    dsimp
+    ring
+  rw [h, empiricalNorm_neg]
+
+/--
+The empirical norm is at most a uniform bound on the sampled coordinates.
+-/
+lemma empiricalNorm_le_of_abs_le
+    (hn : 0 < n) (S : Fin n → 𝒳) (f : 𝒳 → ℝ)
+    {b : ℝ} (hb : 0 ≤ b) (hf : ∀ k, |f (S k)| ≤ b) :
+    empiricalNorm S f ≤ b := by
+  have havg :
+      (n : ℝ)⁻¹ * ∑ k : Fin n, f (S k) ^ 2 ≤ b ^ 2 := by
+    calc
+      (n : ℝ)⁻¹ * ∑ k : Fin n, f (S k) ^ 2 ≤
+          |(n : ℝ)⁻¹ * ∑ k : Fin n, f (S k) ^ 2| :=
+        le_abs_self _
+      _ ≤ b ^ 2 := by
+        apply abs_normalized_fin_sum_le hn
+          (fun k (_ : Unit) ↦ f (S k) ^ 2) (fun _ ↦ ())
+        intro k _
+        rw [abs_of_nonneg (sq_nonneg _)]
+        rw [← sq_abs]
+        exact (sq_le_sq₀ (abs_nonneg _) hb).2 (hf k)
+  calc
+    empiricalNorm S f =
+        Real.sqrt ((n : ℝ)⁻¹ * ∑ k : Fin n, f (S k) ^ 2) := by
+      simp only [empiricalNorm, EmpiricalProcess.empiricalNorm]
+    _ ≤ Real.sqrt (b ^ 2) := Real.sqrt_le_sqrt havg
+    _ = b := by rw [Real.sqrt_sq_eq_abs, abs_of_nonneg hb]
+
+/--
+A pointwise Lipschitz estimate on a sample implies the same estimate for the
+empirical pseudometric.
+-/
+lemma empiricalDist_le_of_abs_sub_le
+    (hn : 0 < n) (S : Fin n → 𝒳) (f g : 𝒳 → ℝ)
+    {b : ℝ} (hb : 0 ≤ b)
+    (hfg : ∀ k, |f (S k) - g (S k)| ≤ b) :
+    empiricalDist S f g ≤ b := by
+  rw [empiricalDist]
+  apply empiricalNorm_le_of_abs_le hn S (f - g) hb
+  intro k
+  exact hfg k
+
+
+
+instance [Nonempty ι] : Nonempty (EmpiricalFunctionSpace F S) :=
+  ⟨⟨Classical.choice inferInstance⟩⟩
+
+/-- `EmpiricalFunctionSpace F S` has the same underlying indices as `ι`. -/
+def empiricalFunctionSpaceEquiv :
+    EmpiricalFunctionSpace F S ≃ ι where
+  toFun q := q.index
+  invFun h := ⟨h⟩
+  left_inv q := by cases q; rfl
+  right_inv _ := rfl
+
+noncomputable instance [Fintype ι] :
+    Fintype (EmpiricalFunctionSpace F S) :=
+  Fintype.ofEquiv ι empiricalFunctionSpaceEquiv.symm
+
+@[simp]
+lemma card_empiricalFunctionSpace [Fintype ι] :
+    Fintype.card (EmpiricalFunctionSpace F S) = Fintype.card ι :=
+  Fintype.card_congr empiricalFunctionSpaceEquiv
+
+-- The left-hand side has a variable head, so v4.33 warns that this would be
+-- tried on every `simp` step. Upstream marks it `@[simp]` and later modules may
+-- rely on that implicitly, so keep the attribute and silence the warning here.
+set_option warning.simp.varHead false in
+@[simp] lemma EmpiricalFunctionSpace.coe_apply
+    (q : EmpiricalFunctionSpace F S) :
+    (q : 𝒳 → ℝ) = F q.index := rfl
+
+/-- A finitely indexed empirical function space is totally bounded. -/
+lemma empiricalFunctionSpace_totallyBounded [Fintype ι] :
+    TotallyBounded
+      (Set.univ : Set (EmpiricalFunctionSpace F S)) :=
+  Set.finite_univ.totallyBounded
 end


### PR DESCRIPTION
Ten declarations ported from `auto-res/lean-rademacher` at **`bc33376`** into
`EmpiricalProcess/FunctionClass.lean`. Pure additions; nothing existing is changed.

## New declarations

Empirical norm and pseudometric:

| Declaration | |
|---|---|
| `empiricalNorm_neg` | invariance under negation |
| `empiricalNorm_le_of_abs_le` | bounded by a uniform bound on the sampled coordinates |
| `empiricalDist_neg_neg` | the pseudometric is unchanged by negating both arguments |
| `empiricalDist_le_of_abs_sub_le` | a pointwise Lipschitz estimate transfers to the pseudometric |

`EmpiricalFunctionSpace`:

| Declaration | |
|---|---|
| `instance [Nonempty ι] : Nonempty (EmpiricalFunctionSpace F S)` | |
| `empiricalFunctionSpaceEquiv` | equivalence with the index type `ι` |
| `noncomputable instance [Fintype ι] : Fintype …` | |
| `card_empiricalFunctionSpace` | cardinality equals that of `ι` |
| `EmpiricalFunctionSpace.coe_apply` | the coercion computation rule |
| `empiricalFunctionSpace_totallyBounded` | total boundedness for a finitely indexed class |

The two instances are what `card_empiricalFunctionSpace` and
`empiricalFunctionSpace_totallyBounded` need; without them those two fail with
`failed to synthesize instance`.

One import added: `StatsMLlib.Analysis.FiniteSample`, matching upstream's own import
list. Import tier unchanged.

## `CoveringNumber/Basic.lean` is deliberately untouched

Appendix C-3 lists it among this PR's targets. Examining its four upstream lemmas
first, none of them should be ported:

| Upstream | Disposition |
|---|---|
| `coveringNumber_exists` | internal to upstream's `Nat.find`-based definition; zero downstream uses |
| `coveringNumber_eq` | `coveringNumber ha ε = Nat.find …`, by `dif_pos`; same |
| `coveringNumber_le_card_of_cover` | StatsMLlib's existing `coveringNumber_le_card` is the same statement |
| `coveringNumber_le_fintype_card` | per B-2, `coveringNumber_le_card` with `Finset.univ`; needed only at §17.1, i.e. PR 08 |

Upstream defines

```lean
noncomputable def coveringNumber (ha : TotallyBounded A) (ε : ℝ) : ℕ :=
  if h : ε > 0 then Nat.find (coveringNumber_exists ha h) else 0
```

whereas StatsMLlib's canonical `coveringNumber : WithTop ℕ` takes no
total-boundedness proof term. That is appendix B-1's divergence, and §11-4 both
forbids changing the definition or its existing signatures — thirteen files reference
it — and says upstream's proofs cannot be pasted. So the module is left alone, and the
two lemmas that do have downstream consumers are picked up in PR 08 where their
necessity is established.

This means the PR is 10 declarations rather than C-3's estimate of 11, and touches one
module rather than three.

## Provenance against `bc33376`

`upstream-only = 0` for the pair: nothing from `Entropy/PseudoMetric.lean` that belongs
in these modules is left behind.

**Two repairs were needed, and neither is a Lean version difference.** Both come from
StatsMLlib defining `empiricalNorm` as a view of the canonical one:

```lean
-- upstream: a direct definition
noncomputable def empiricalNorm (S : Fin n → 𝒳) (f : 𝒳 → ℝ) : ℝ :=
  Real.sqrt ((1 / n) * ∑ i : Fin n, (f (S i)^2))

-- StatsMLlib: a view of EmpiricalProcess.empiricalNorm
noncomputable abbrev empiricalNorm (S : Fin n → 𝒳) (f : 𝒳 → ℝ) : ℝ :=
  EmpiricalProcess.empiricalNorm n (fun i ↦ f (S i))
```

so upstream's `simp [empiricalNorm]` unfolds one layer here and stops, leaving
`unsolved goals`:

```diff
-  simp [empiricalNorm]
+  simp [empiricalNorm, EmpiricalProcess.empiricalNorm]
```

This is the same shape as B-1's `coveringNumber` split, and `empiricalNorm_def`
already in this module uses exactly that simp set.

Separately, `EmpiricalFunctionSpace.coe_apply` has a variable as its left-hand side
head, which v4.33 warns about for a global `@[simp]` lemma. `@[local simp]` does not
silence it, and dropping `@[simp]` would quietly change what later `simp` calls can
close, so the attribute is kept with `set_option warning.simp.varHead false in` and a
comment giving the reason.

## Verification

- `lake build` green across all 8801 jobs.
- The changed file re-elaborates with completely empty output: no warnings.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- 93 added lines, 10 declarations — inside the C-1 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
