### PR TITLE
Add the dense restriction of a family to a countable dense sequence

### DIFF
--- a/StatsMLlib/Topology/SeparableSpace/Supremum.lean
+++ b/StatsMLlib/Topology/SeparableSpace/Supremum.lean
@@ -8,8 +8,9 @@ import Mathlib.Order.ConditionallyCompleteLattice.Indexed
 import Mathlib.Topology.Order.Lattice
 import Mathlib.Data.Real.Basic
 import Mathlib.Topology.Algebra.Ring.Real
+import Mathlib.MeasureTheory.MeasurableSpace.Basic
 
-universe u v
+universe u v w
 
 open TopologicalSpace
 
@@ -78,3 +79,40 @@ theorem separableSpaceSup_eq_real {X : Type u} [TopologicalSpace X] [SeparableSp
     calc
       _ = 0 := Real.iSup_of_not_bddAbove bdd
       _ = _ := (Real.iSup_of_not_bddAbove this).symm
+
+/--
+Restriction of a family to Mathlib's chosen countable dense sequence.
+
+The definition includes its value, rather than merely introducing a type:
+
+`denseRestriction F = F ∘ denseSeq H`.
+-/
+noncomputable abbrev denseRestriction
+    {H : Type u} {α : Type w}
+    [TopologicalSpace H] [SeparableSpace H] [Nonempty H]
+    (F : H → α) : ℕ → α :=
+  F ∘ denseSeq H
+
+@[simp]
+lemma denseRestriction_apply
+    {H : Type u} {α : Type w}
+    [TopologicalSpace H] [SeparableSpace H] [Nonempty H]
+    (F : H → α) (i : ℕ) :
+    denseRestriction F i = F (denseSeq H i) :=
+  rfl
+
+lemma measurable_denseRestriction_apply
+    {H : Type u} {α : Type w} {β : Type*}
+    [TopologicalSpace H] [SeparableSpace H] [Nonempty H]
+    [MeasurableSpace α] [MeasurableSpace β]
+    {F : H → α → β} (hF : ∀ h, Measurable (F h)) (i : ℕ) :
+    Measurable (denseRestriction F i) :=
+  hF (denseSeq H i)
+
+lemma abs_denseRestriction_le
+    {H : Type u} {α : Type w}
+    [TopologicalSpace H] [SeparableSpace H] [Nonempty H]
+    {F : H → α → ℝ} {b : ℝ}
+    (hF : ∀ h x, |F h x| ≤ b) :
+    ∀ i x, |denseRestriction F i x| ≤ b :=
+  fun i x ↦ hF (denseSeq H i) x


### PR DESCRIPTION
Four declarations ported from `auto-res/lean-rademacher` at **`bc33376`** into
`Topology/SeparableSpace/Supremum.lean`. Pure additions.

## Why this is `05a`

Appendix C-3's PR 05 measures **22 upstream declarations** against the C-1 ceiling of
10–20, so it splits. The boundary is upstream's own import structure —
`Generalization/Separable.lean` imports both `Generalization/Countable.lean` and
`ForMathlib/Topology/SeparableSpace.lean`:

- **05a (this PR)** — the topological layer: `denseRestriction` and friends, 4 declarations.
- **05b** — the countable-class bounds in `UniformDeviation/Bounds.lean`, 9 declarations.
- **05c** — the separable-class bounds, 9 declarations, which use both of the above.

Each part compiles on its own. Keeping 05a separate also keeps a `Topology` (tier 0)
change out of a `LearningTheory` (tier 3) PR.

## New declarations

| Declaration | |
|---|---|
| `denseRestriction` | `F ∘ denseSeq H` — restriction of a family to Mathlib's chosen countable dense sequence |
| `denseRestriction_apply` | the computation rule, by `rfl` |
| `measurable_denseRestriction_apply` | each restricted function is measurable |
| `abs_denseRestriction_le` | a uniform bound transfers to the restriction |

This is the bridge that lets a separable class be handled by the countable-class
results: 05c will use it to reduce an uncountable supremum to a countable one.

One import added, `Mathlib.MeasureTheory.MeasurableSpace.Basic`, for the measurability
lemma — matching upstream's own import list.

## One repair, and it is worth reading

The `universe` line gains `w`. Upstream's declarations are written as
`{H : Type u} {α : Type w}` and upstream runs with `autoImplicit` on, so `w` is
auto-bound there. This package disables that through `leanOptions`, so `w` must be
declared.

What makes this worth a note: **`lake env lean` did not catch it.** That command sets
only `LEAN_PATH`; it does not pass the package's `leanOptions`, so it runs with
`autoImplicit` on and every style linter off. The file elaborated with completely empty
output, and `lake build` then failed with `unknown universe level w`.

The consequence is that `lake env lean` is a fast inner loop, not a verdict — and that
`lake build` is where `autoImplicit false` and the linters actually apply. The port's
gate script has been changed accordingly: it now touches the changed files before
building, so their modules genuinely rebuild, and fails on any `warning:` in the build
output rather than trusting a per-file elaboration that runs without the linters.

## Provenance against `bc33376`

All four declarations are byte-identical to their upstream originals, and
`upstream-only = 0`: nothing from `ForMathlib/Topology/SeparableSpace.lean` is left
behind.

## Verification

- `lake build` green across all 8801 jobs, with the changed file touched first so it
  really rebuilds, and **no warnings** in the build output.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- Import direction unchanged; `Topology` is tier 0 and imports only Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
