### PR TITLE
Add countable-class uniform deviation bounds

### DIFF
--- a/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
@@ -8,6 +8,7 @@ import StatsMLlib.LearningTheory.UniformDeviation.Defs
 import StatsMLlib.Probability.Concentration.McDiarmid
 import StatsMLlib.LearningTheory.UniformDeviation.BoundedDifference
 import StatsMLlib.Topology.SeparableSpace.Supremum
+import StatsMLlib.MeasureTheory.Measure.Real
 
 /-!
 # Uniform-Deviation Bounds
@@ -238,4 +239,238 @@ theorem uniform_deviation_tail_bound_separable_of_pos
       uniform_deviation_tail_bound_separable (μ := μ) f hf X hX (le_of_lt hb) hf' hf'' ht' hε
     _ = _ := by dsimp only [t]; field_simp
 
+
+private lemma normalized_two_mul_bound_mcdiarmid_scale
+    (hn : 0 < n) {b t : ℝ} (ht : t * b ^ 2 ≤ 1 / 2) :
+    ((n : ℝ) * t / 2) * (n : ℝ) * ((n : ℝ)⁻¹ * 2 * b) ^ 2 ≤ 1 := by
+  calc
+    ((n : ℝ) * t / 2) * (n : ℝ) * ((n : ℝ)⁻¹ * 2 * b) ^ 2 =
+        2 * (t * b ^ 2) := by
+          field_simp
+    _ ≤ 2 * (1 / 2 : ℝ) := by gcongr
+    _ = 1 := by norm_num
+
+/--
+Bridge from an upper bound on expected Rademacher complexity to an expected
+uniform-deviation bound.
+-/
+theorem uniform_deviation_expectation_le_of_rademacher_le
+    [Nonempty ι] [Countable ι] [IsProbabilityMeasure μ]
+    (hn : 0 < n) (X : Ω → 𝒳)
+    (hf : ∀ i, Measurable (f i ∘ X))
+    {b C : ℝ} (hb : 0 ≤ b) (hf' : ∀ i x, |f i x| ≤ b)
+    (hC : rademacherComplexity n f μ X ≤ C) :
+    μⁿ[fun ω : Fin n → Ω ↦ uniformDeviation n f μ X (X ∘ ω)] ≤
+      2 * C := by
+  calc
+    _ ≤ 2 * rademacherComplexity n f μ X :=
+      uniform_deviation_expectation_le_two_smul_rademacher_complexity
+        hn X hf hb hf'
+    _ ≤ 2 * C := by
+      simpa only [nsmul_eq_mul] using
+        mul_le_mul_of_nonneg_left hC (show (0 : ℝ) ≤ 2 by norm_num)
+
+/--
+A uniform fixed-sample upper bound on empirical Rademacher complexity bounds
+the expected uniform deviation.
+-/
+theorem uniform_deviation_expectation_le_of_empirical_le_countable
+    [Nonempty ι] [Countable ι] [IsProbabilityMeasure μ]
+    (hn : 0 < n) (X : Ω → 𝒳)
+    (hf : ∀ i, Measurable (f i ∘ X))
+    {b C : ℝ} (hb : 0 ≤ b) (hf' : ∀ i x, |f i x| ≤ b)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n f S ≤ C) :
+    μⁿ[fun ω : Fin n → Ω ↦ uniformDeviation n f μ X (X ∘ ω)] ≤
+      2 * C := by
+  apply uniform_deviation_expectation_le_of_rademacher_le hn X hf hb hf'
+  exact rademacherComplexity_le_of_empirical_le_countable hf hb hf' hC
+
+/--
+Lower-tail concentration of empirical Rademacher complexity around its
+expectation.
+-/
+theorem empiricalRademacherComplexity_lower_tail_countable
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty ι] [Countable ι]
+    [IsProbabilityMeasure μ]
+    (f : ι → 𝒳 → ℝ) (hf : ∀ i, Measurable (f i))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b : ℝ} (hf' : ∀ i x, |f i x| ≤ b)
+    {t : ℝ} (ht : t * b ^ 2 ≤ 1 / 2)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {ω : Fin n → Ω |
+      empiricalRademacherComplexity n f (X ∘ ω) -
+        rademacherComplexity n f μ X ≤ -ε}).toReal ≤
+      (-ε ^ 2 * t * n).exp := by
+  by_cases hn : n = 0
+  · simp [hn, ← measureReal_def]
+  have hn : 0 < n := Nat.pos_of_ne_zero hn
+  calc
+    _ ≤ (-2 * ε ^ 2 * ((n : ℝ) * t / 2)).exp := by
+      simpa only [rademacherComplexity, Set.ofPred] using
+        (mcdiarmid_inequality_neg_iid_of_const
+          (μ := μ) (ι := Fin n) (X' := X)
+          (f' := fun S : Fin n → 𝒳 ↦ empiricalRademacherComplexity n f S)
+          (c := (n : ℝ)⁻¹ * 2 * b) hX
+          (empiricalRademacherComplexity_bounded_difference
+            (n := n) (f := f) hn hf')
+          (measurable_empiricalRademacherComplexity_comp
+            (Ω := 𝒳) (Z := 𝒳) (n := n) (f := f) (X := id)
+            (fun i ↦ by simpa using hf i))
+          hε (by simpa using normalized_two_mul_bound_mcdiarmid_scale hn ht))
+    _ = _ := congr_arg _ (by ring)
+
+/-- Optimized empirical-complexity lower tail with `t = 1 / (2 * b^2)`. -/
+theorem empiricalRademacherComplexity_lower_tail_countable_of_pos
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty ι] [Countable ι]
+    [IsProbabilityMeasure μ]
+    (f : ι → 𝒳 → ℝ) (hf : ∀ i, Measurable (f i))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b : ℝ} (hb : 0 < b) (hf' : ∀ i x, |f i x| ≤ b)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {ω : Fin n → Ω |
+      empiricalRademacherComplexity n f (X ∘ ω) -
+        rademacherComplexity n f μ X ≤ -ε}).toReal ≤
+      (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  let t := 1 / (2 * b ^ 2)
+  have ht : t * b ^ 2 ≤ 1 / 2 := le_of_eq (by
+    dsimp only [t]
+    field_simp)
+  calc
+    _ ≤ (-ε ^ 2 * t * n).exp :=
+      empiricalRademacherComplexity_lower_tail_countable
+        (μ := μ) f hf X hX hf' ht hε
+    _ = _ := by
+      dsimp only [t]
+      field_simp
+
+/--
+Replace expected Rademacher complexity in the countable-class tail bound by
+any deterministic upper bound `C`.
+-/
+theorem uniform_deviation_tail_bound_countable_of_rademacher_le
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty ι] [Countable ι]
+    [IsProbabilityMeasure μ]
+    (f : ι → 𝒳 → ℝ) (hf : ∀ i, Measurable (f i))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C : ℝ} (hb : 0 < b) (hf' : ∀ i x, |f i x| ≤ b)
+    (hC : rademacherComplexity n f μ X ≤ C)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {ω |
+      2 * C + ε ≤ uniformDeviation n f μ X (X ∘ ω)}).toReal ≤
+      (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  calc
+    _ ≤ (μⁿ {ω |
+        2 * rademacherComplexity n f μ X + ε ≤
+          uniformDeviation n f μ X (X ∘ ω)}).toReal := by
+      apply measureReal_superlevel_mono
+      intro ω
+      gcongr
+    _ ≤ _ :=
+      uniform_deviation_tail_bound_countable_of_pos
+        (μ := μ) f hf X hX hb hf' hε
+
+/--
+Optimized countable-class tail bound with a uniform fixed-sample upper bound
+on empirical Rademacher complexity.
+-/
+theorem uniform_deviation_tail_bound_countable_of_empirical_le
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty ι] [Countable ι]
+    [IsProbabilityMeasure μ]
+    (f : ι → 𝒳 → ℝ) (hf : ∀ i, Measurable (f i))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C : ℝ} (hb : 0 < b) (hf' : ∀ i x, |f i x| ≤ b)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n f S ≤ C)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {ω |
+      2 * C + ε ≤ uniformDeviation n f μ X (X ∘ ω)}).toReal ≤
+      (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  apply uniform_deviation_tail_bound_countable_of_rademacher_le
+    (μ := μ) f hf X hX hb hf' _ hε
+  exact rademacherComplexity_le_of_empirical_le_countable
+    (fun i ↦ (hf i).comp hX) hb.le hf' hC
+
+/--
+Sample-dependent countable-class tail bound. The threshold contains the
+empirical Rademacher complexity of the observed sample. The factor `3` is
+obtained by combining two concentration events with a union bound.
+-/
+theorem uniform_deviation_tail_bound_countable_of_empirical_complexity
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty ι] [Countable ι]
+    [IsProbabilityMeasure μ]
+    (f : ι → 𝒳 → ℝ) (hf : ∀ i, Measurable (f i))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b : ℝ} (hb : 0 < b) (hf' : ∀ i x, |f i x| ≤ b)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {ω : Fin n → Ω |
+      2 * empiricalRademacherComplexity n f (X ∘ ω) + 3 * ε ≤
+        uniformDeviation n f μ X (X ∘ ω)}).toReal ≤
+      2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  let A : Set (Fin n → Ω) :=
+    {ω | 2 * rademacherComplexity n f μ X + ε ≤
+      uniformDeviation n f μ X (X ∘ ω)}
+  let B : Set (Fin n → Ω) :=
+    {ω | empiricalRademacherComplexity n f (X ∘ ω) -
+      rademacherComplexity n f μ X ≤ -ε}
+  have hsubset :
+      {ω : Fin n → Ω |
+        2 * empiricalRademacherComplexity n f (X ∘ ω) + 3 * ε ≤
+          uniformDeviation n f μ X (X ∘ ω)} ⊆ A ∪ B := by
+    intro ω hω
+    simp only [Set.mem_ofPred_eq] at hω
+    simp only [Set.mem_union, Set.mem_ofPred_eq, A, B]
+    by_cases hA :
+        2 * rademacherComplexity n f μ X + ε ≤
+          uniformDeviation n f μ X (X ∘ ω)
+    · exact Or.inl hA
+    · right
+      simp only [not_le] at hA
+      norm_num at hω hA ⊢
+      linarith
+  calc
+    _ ≤ (μⁿ).real (A ∪ B) := measureReal_mono hsubset
+    _ ≤ (μⁿ).real A + (μⁿ).real B := measureReal_union_le A B
+    _ ≤ (-ε ^ 2 * n / (2 * b ^ 2)).exp +
+          (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+      apply add_le_add
+      · exact uniform_deviation_tail_bound_countable_of_pos
+          (μ := μ) f hf X hX hb hf' hε
+      · exact empiricalRademacherComplexity_lower_tail_countable_of_pos
+          (μ := μ) f hf X hX hb hf' hε
+    _ ≤ 2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+      have h :
+          (-ε ^ 2 * n / (2 * b ^ 2)).exp +
+              (-ε ^ 2 * n / (2 * b ^ 2)).exp =
+            2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+        ring
+      exact h.le
+  all_goals exact le_rfl
+
+/--
+Sample-dependent countable-class tail bound with an arbitrary pointwise upper
+bound `C S` on empirical Rademacher complexity.
+-/
+theorem uniform_deviation_tail_bound_countable_of_sample_empirical_le
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty ι] [Countable ι]
+    [IsProbabilityMeasure μ]
+    (f : ι → 𝒳 → ℝ) (hf : ∀ i, Measurable (f i))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    (C : (Fin n → 𝒳) → ℝ)
+    {b : ℝ} (hb : 0 < b) (hf' : ∀ i x, |f i x| ≤ b)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n f S ≤ C S)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {ω : Fin n → Ω |
+      2 * C (X ∘ ω) + 3 * ε ≤
+        uniformDeviation n f μ X (X ∘ ω)}).toReal ≤
+      2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  calc
+    _ ≤ (μⁿ {ω : Fin n → Ω |
+        2 * empiricalRademacherComplexity n f (X ∘ ω) + 3 * ε ≤
+          uniformDeviation n f μ X (X ∘ ω)}).toReal := by
+      apply measureReal_superlevel_mono
+      intro ω
+      gcongr
+      exact hC (X ∘ ω)
+    _ ≤ _ :=
+      uniform_deviation_tail_bound_countable_of_empirical_complexity
+        (μ := μ) f hf X hX hb hf' hε
 end


### PR DESCRIPTION
Nine declarations ported from `auto-res/lean-rademacher` at **`bc33376`**, appended to
`UniformDeviation/Bounds.lean`. Pure additions; nothing existing is changed.

Second of three parts of appendix C-3's PR 05 (22 declarations against the C-1 ceiling
of 20). #16 carried the topological layer; 05c will carry the separable-class bounds,
which consume both.

## New declarations

| Declaration | |
|---|---|
| `normalized_two_mul_bound_mcdiarmid_scale` | the scale computation feeding McDiarmid |
| `uniform_deviation_expectation_le_of_rademacher_le` | expectation bound from a bound on `rademacherComplexity` |
| `uniform_deviation_expectation_le_of_empirical_le_countable` | …from a bound on the empirical complexity |
| `empiricalRademacherComplexity_lower_tail_countable` | lower tail of the empirical complexity |
| `empiricalRademacherComplexity_lower_tail_countable_of_pos` | the `0 < n` form |
| `uniform_deviation_tail_bound_countable_of_rademacher_le` | tail bound, caller controls `rademacherComplexity` |
| `uniform_deviation_tail_bound_countable_of_empirical_le` | …controls the empirical complexity uniformly |
| `uniform_deviation_tail_bound_countable_of_empirical_complexity` | …in terms of the empirical complexity itself |
| `uniform_deviation_tail_bound_countable_of_sample_empirical_le` | …sample-dependent form |

The four tail bounds differ only in which quantity the caller already controls; they
are what the linear-predictor and RKHS PRs will instantiate.

One import added, `StatsMLlib.MeasureTheory.Measure.Real`, matching upstream's own
import list.

## Provenance against `bc33376`

`upstream-only = 0`: nothing from `Generalization/Countable.lean` is left behind.

**Two repairs, and both are genuine v4.33 renames that surface as type errors rather
than as deprecation warnings.**

**1. `setOf` is deprecated; `{x | p x}` now elaborates to `Set.ofPred`.**
`Mathlib/Data/Set/Defs.lean:70` carries
`@[deprecated (since := "2026-07-09")] alias setOf := Set.ofPred`. Since
`Set.ofPred p := p` is the identity, the two forms remain definitionally equal, but
`simp` is syntactic and no longer bridges them:

```diff
-      simpa only [rademacherComplexity] using
+      simpa only [rademacherComplexity, Set.ofPred] using
```

The error prints two types that look nearly identical — one `μ fun ω ↦ …`, the other
`μ {ω | …}` — which is the tell. The membership-level form of the same rename,
`Set.mem_setOf_eq` → `Set.mem_ofPred_eq`, appears twice more in the ported text and is
fixed with it; that one does warn.

**2. `μ.real s` and `(μ s).toReal` no longer interchange.**

```diff
-  · simpa [hn] using measureReal_le_one
+  · simp [hn, ← measureReal_def]
```

`measureReal_le_one` is stated with `μ.real s` while the ported statement says
`(μ s).toReal`; `measureReal_def` bridges them, used right-to-left. `simp` then closes
the goal on its own, so the `using` clause is dropped — otherwise the build warns
`try 'simp' instead of 'simpa'`.

This is the first time §11-0's `Measure.real` hot spot has actually bitten. The
calibration spike found no drift there, so the estimate is updated rather than
contradicted.

## Verification

- `lake build` green across all 8801 jobs, changed file touched first so it really
  rebuilds, and **no warnings** in the build output.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- Import direction unchanged.
- 235 added lines, 9 declarations — inside the C-1 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
