### PR TITLE
Add separable-class uniform deviation bounds

### DIFF
--- a/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
@@ -473,4 +473,248 @@ theorem uniform_deviation_tail_bound_countable_of_sample_empirical_le
     _ ≤ _ :=
       uniform_deviation_tail_bound_countable_of_empirical_complexity
         (μ := μ) f hf X hX hb hf' hε
+
+
+-- The separable results below are indexed by a topological hypothesis space,
+-- which upstream calls `H`; the countable results above use `ι`. They play
+-- different roles, so both names are kept.
+variable {H : Type v}
+
+/--
+Empirical Rademacher complexity is unchanged after restricting a continuous
+family to the chosen countable dense sequence.
+-/
+lemma empiricalRademacherComplexity_denseRestriction
+    [Nonempty H] [TopologicalSpace H] [SeparableSpace H]
+    (n : ℕ) {F : H → 𝒳 → ℝ}
+    (hF : ∀ x : 𝒳, Continuous fun h ↦ F h x) (S : Fin n → 𝒳) :
+    empiricalRademacherComplexity n F S =
+      empiricalRademacherComplexity n (denseRestriction F) S := by
+  dsimp [empiricalRademacherComplexity]
+  congr
+  ext σ
+  apply separableSpaceSup_eq_real
+  continuity
+
+/--
+Expected Rademacher complexity is unchanged after restriction to
+`denseRestriction F`.
+-/
+lemma rademacherComplexity_denseRestriction
+    [Nonempty H] [TopologicalSpace H] [SeparableSpace H]
+    (n : ℕ) (F : H → 𝒳 → ℝ)
+    (hF : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (μ : Measure Ω) (X : Ω → 𝒳) :
+    rademacherComplexity n F μ X =
+      rademacherComplexity n (denseRestriction F) μ X := by
+  dsimp [rademacherComplexity]
+  congr
+  ext S
+  exact empiricalRademacherComplexity_denseRestriction n hF (X ∘ S)
+
+/--
+A uniform fixed-sample bound for a separable class lifts to expected
+Rademacher complexity through `denseRestriction`.
+-/
+theorem rademacherComplexity_le_of_empirical_le_separable
+    [Nonempty H] [TopologicalSpace H] [SeparableSpace H]
+    [IsProbabilityMeasure μ]
+    (F : H → 𝒳 → ℝ) (X : Ω → 𝒳)
+    (hF_meas : ∀ h, Measurable (F h ∘ X))
+    {b C : ℝ} (hb : 0 ≤ b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C) :
+    rademacherComplexity n F μ X ≤ C := by
+  rw [rademacherComplexity_denseRestriction n F hF_cont μ X]
+  apply rademacherComplexity_le_of_empirical_le_countable
+    (f := denseRestriction F) (μ := μ)
+  · exact fun i ↦ hF_meas (denseSeq H i)
+  · exact hb
+  · exact abs_denseRestriction_le hF_bound
+  · intro S
+    rw [← empiricalRademacherComplexity_denseRestriction n hF_cont S]
+    exact hC S
+
+/--
+Uniform deviation is unchanged after restricting a continuous and uniformly
+bounded family to `denseRestriction F`.
+-/
+lemma uniformDeviation_denseRestriction
+    [MeasurableSpace 𝒳]
+    [Nonempty H] [TopologicalSpace H] [SeparableSpace H]
+    [FirstCountableTopology H]
+    (n : ℕ) (F : H → 𝒳 → ℝ)
+    (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b : ℝ} (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (μ : Measure Ω) [IsFiniteMeasure μ] :
+    uniformDeviation n F μ X =
+      uniformDeviation n (denseRestriction F) μ X := by
+  ext S
+  dsimp [uniformDeviation]
+  apply separableSpaceSup_eq_real
+  apply Continuous.abs
+  apply Continuous.sub
+  · continuity
+  · have hdominated :
+        ∀ h : H, ∀ᵐ ω : Ω ∂μ, ‖F h (X ω)‖ ≤ b := by
+      intro h
+      filter_upwards with ω
+      exact hF_bound h (X ω)
+    apply MeasureTheory.continuous_of_dominated _ hdominated
+    · exact MeasureTheory.integrable_const _
+    · filter_upwards with ω
+      continuity
+    · intro h
+      exact (hF_meas h).comp hX |>.aestronglyMeasurable
+
+/--
+Expected uniform-deviation bound for a separable class from a deterministic
+fixed-sample empirical Rademacher bound.
+-/
+theorem uniform_deviation_expectation_le_of_empirical_le_separable
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C : ℝ} (hb : 0 ≤ b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C) :
+    μⁿ[fun S : Fin n → Ω ↦ uniformDeviation n F μ X (X ∘ S)] ≤
+      2 * C := by
+  calc
+    μⁿ[fun S : Fin n → Ω ↦ uniformDeviation n F μ X (X ∘ S)] =
+        μⁿ[fun S : Fin n → Ω ↦
+          uniformDeviation n (denseRestriction F) μ X (X ∘ S)] := by
+      apply integral_congr_ae
+      filter_upwards with S
+      exact congrFun
+        (uniformDeviation_denseRestriction
+          n F hF_meas X hX hF_bound hF_cont μ) (X ∘ S)
+    _ ≤ 2 * C := by
+      apply uniform_deviation_expectation_le_of_empirical_le_countable
+        (f := denseRestriction F) (μ := μ) hn X
+      · exact fun i ↦ (hF_meas (denseSeq H i)).comp hX
+      · exact hb
+      · exact abs_denseRestriction_le hF_bound
+      · intro S
+        rw [← empiricalRademacherComplexity_denseRestriction n hF_cont S]
+        exact hC S
+
+/--
+Replace expected Rademacher complexity in the separable-class tail bound by
+any deterministic upper bound `C`.
+-/
+theorem uniform_deviation_tail_bound_separable_of_rademacher_le
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hC : rademacherComplexity n F μ X ≤ C)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S |
+      2 * C + ε ≤ uniformDeviation n F μ X (X ∘ S)}).toReal ≤
+      (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  calc
+    _ ≤ (μⁿ {S |
+        2 * rademacherComplexity n F μ X + ε ≤
+          uniformDeviation n F μ X (X ∘ S)}).toReal := by
+      apply measureReal_superlevel_mono
+      intro S
+      gcongr
+    _ ≤ _ :=
+      uniform_deviation_tail_bound_separable_of_pos
+        (μ := μ) F hF_meas X hX hb hF_bound hF_cont hε
+
+/--
+Separable-class tail bound with a deterministic fixed-sample upper bound on
+empirical Rademacher complexity.
+-/
+theorem uniform_deviation_tail_bound_separable_of_empirical_le
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S |
+      2 * C + ε ≤ uniformDeviation n F μ X (X ∘ S)}).toReal ≤
+      (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  apply uniform_deviation_tail_bound_separable_of_rademacher_le
+    (μ := μ) F hF_meas X hX hb hF_bound hF_cont _ hε
+  exact rademacherComplexity_le_of_empirical_le_separable
+    F X (fun h ↦ (hF_meas h).comp hX) hb.le hF_bound hF_cont hC
+
+/--
+Sample-dependent separable-class tail bound retaining the observed empirical
+Rademacher complexity in the threshold.
+-/
+theorem uniform_deviation_tail_bound_separable_of_empirical_complexity
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S : Fin n → Ω |
+      2 * empiricalRademacherComplexity n F (X ∘ S) + 3 * ε ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤
+      2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  calc
+    _ = (μⁿ {S : Fin n → Ω |
+        2 * empiricalRademacherComplexity n (denseRestriction F) (X ∘ S) +
+            3 * ε ≤
+          uniformDeviation n (denseRestriction F) μ X (X ∘ S)}).toReal := by
+      congr
+      ext S
+      rw [empiricalRademacherComplexity_denseRestriction n hF_cont (X ∘ S)]
+      rw [uniformDeviation_denseRestriction
+        n F hF_meas X hX hF_bound hF_cont μ]
+    _ ≤ _ :=
+      uniform_deviation_tail_bound_countable_of_empirical_complexity
+        (μ := μ) (denseRestriction F)
+        (measurable_denseRestriction_apply hF_meas)
+        X hX hb (abs_denseRestriction_le hF_bound) hε
+
+/--
+Sample-dependent separable-class tail bound with a pointwise upper bound
+`C S` on empirical Rademacher complexity.
+-/
+theorem uniform_deviation_tail_bound_separable_of_sample_empirical_le
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    (C : (Fin n → 𝒳) → ℝ)
+    {b : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C S)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S : Fin n → Ω |
+      2 * C (X ∘ S) + 3 * ε ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤
+      2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  calc
+    _ ≤ (μⁿ {S : Fin n → Ω |
+        2 * empiricalRademacherComplexity n F (X ∘ S) + 3 * ε ≤
+          uniformDeviation n F μ X (X ∘ S)}).toReal := by
+      apply measureReal_superlevel_mono
+      intro S
+      gcongr
+      exact hC (X ∘ S)
+    _ ≤ _ :=
+      uniform_deviation_tail_bound_separable_of_empirical_complexity
+        (μ := μ) F hF_meas X hX hb hF_bound hF_cont hε
 end


### PR DESCRIPTION
Nine declarations ported from `auto-res/lean-rademacher` at **`bc33376`**, appended to
`UniformDeviation/Bounds.lean`. Pure additions; nothing existing is changed.

Third and last part of appendix C-3's PR 05. #16 carried the topological layer, #18 the
countable-class bounds, and this one joins them.

## New declarations

Reduction of a separable class to a countable one, through `denseRestriction` (#16):

| Declaration | |
|---|---|
| `empiricalRademacherComplexity_denseRestriction` | the empirical complexity is unchanged by the restriction |
| `rademacherComplexity_denseRestriction` | so is the expected complexity |
| `uniformDeviation_denseRestriction` | and so is uniform deviation |
| `rademacherComplexity_le_of_empirical_le_separable` | pointwise empirical bound transfers to the expectation |
| `uniform_deviation_expectation_le_of_empirical_le_separable` | the expectation bound |
| `uniform_deviation_tail_bound_separable_of_rademacher_le` | tail bound, caller controls `rademacherComplexity` |
| `uniform_deviation_tail_bound_separable_of_empirical_le` | …controls the empirical complexity uniformly |
| `uniform_deviation_tail_bound_separable_of_empirical_complexity` | …in terms of the empirical complexity itself |
| `uniform_deviation_tail_bound_separable_of_sample_empirical_le` | …sample-dependent form |

The three `denseRestriction` equalities are the point: a continuous family and its
restriction to Mathlib's chosen countable dense sequence have the same complexity, so
the countable-class results of #18 apply unchanged. The four tail bounds mirror the
countable ones one for one.

## One scope addition

A file-level `variable {H : Type v}` is introduced immediately before the ported block.

Upstream's `Generalization/Separable.lean` indexes these results by `H`, a *topological*
hypothesis space, while `Generalization/Countable.lean` — and this module's existing
content — uses `ι`. The two play different roles, so both names are kept, with a comment
in the source saying why, rather than rewriting upstream's text to reuse `ι`.

No instance is added at file level: each theorem carries its own `[TopologicalSpace H]`
and `[SeparableSpace H]` assumptions, exactly as upstream does and as this module's
existing `uniform_deviation_tail_bound_separable` does for `ι`.

## Provenance against `bc33376`

`upstream-only = 0`: nothing from `Generalization/Separable.lean` is left behind.

**No v4.33 repair was needed** — all nine declarations compile as written upstream. The
only edit to upstream text was supplying the `H` binder, which upstream provides through
its own file-level `variable` line.

That contrasts with #18, where the same source repository needed two repairs; the
version diff is concentrated in proofs that touch `Measure.real` and set-builder
notation, and these nine touch neither.

## Verification

- `lake build` green across all 8801 jobs, changed file touched first so it really
  rebuilds, and **no warnings** in the build output.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- Import direction unchanged; no new imports were needed.
- 244 added lines, 9 declarations — inside the C-1 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
