### PR TITLE
Add confidence-parameter forms of the uniform deviation bounds

### DIFF
--- a/FILE_TREE.md
+++ b/FILE_TREE.md
@@ -1,21 +1,21 @@
 # StatsMLlib file tree
 
 This document presents the public Lean source tree after the Mathlib-style subject refactor.
-`StatsMLlib/` contains 95 Lean modules under eight layer-one directories and no root-level Lean
+`StatsMLlib/` contains 96 Lean modules under eight layer-one directories and no root-level Lean
 files. A filesystem path such as `StatsMLlib/Probability/Process/Dudley.lean` corresponds to the Lean
 module `StatsMLlib.Probability.Process.Dudley`.
 
 | Layer | Modules |
 | --- | ---: |
 | `Analysis` | 5 |
-| `LearningTheory` | 14 |
+| `LearningTheory` | 15 |
 | `LinearAlgebra` | 5 |
 | `MeasureTheory` | 3 |
 | `Order` | 1 |
 | `Probability` | 44 |
 | `Statistics` | 21 |
 | `Topology` | 2 |
-| **Total** | **95** |
+| **Total** | **96** |
 
 ```text
 StatsMLlib/
@@ -47,6 +47,7 @@ StatsMLlib/
 │   └── UniformDeviation/
 │       ├── BoundedDifference.lean
 │       ├── Bounds.lean
+│       ├── Confidence.lean
 │       └── Defs.lean
 ├── LinearAlgebra/
 │   └── Matrix/

--- a/StatsMLlib/LearningTheory/UniformDeviation/Confidence.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Confidence.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import StatsMLlib.LearningTheory.UniformDeviation.Bounds
+import StatsMLlib.Probability.Concentration.Confidence
+
+/-!
+# Confidence-parameter generalization bounds
+
+This module turns the `ε`-tail bounds of
+`StatsMLlib.LearningTheory.UniformDeviation.Bounds`, for both countable and
+separable classes, into statements with failure probability `0 < δ ≤ 1`.
+-/
+
+section
+
+universe u v w
+
+open MeasureTheory ProbabilityTheory Real TopologicalSpace
+open scoped ENNReal
+
+variable {n : ℕ}
+variable {Ω : Type u} [MeasurableSpace Ω] {H : Type v} {𝒳 : Type w}
+variable {μ : Measure Ω}
+
+local notation "μⁿ" => Measure.pi (fun _ ↦ μ)
+
+/--
+Confidence radius for a tail estimate without an additional prefactor:
+
+`deterministicConfidenceRadius b δ n =
+  b * √(2 * log (1 / δ) / n)`.
+-/
+noncomputable def deterministicConfidenceRadius
+    (b δ : ℝ) (n : ℕ) : ℝ :=
+  confidenceRadius 1 b δ n
+
+/--
+Confidence radius for a union bound with prefactor `2`:
+
+`sampleConfidenceRadius b δ n =
+  b * √(2 * log (2 / δ) / n)`.
+-/
+noncomputable def sampleConfidenceRadius
+    (b δ : ℝ) (n : ℕ) : ℝ :=
+  confidenceRadius 2 b δ n
+
+lemma deterministicConfidenceRadius_nonneg
+    {b δ : ℝ} (hb : 0 ≤ b) :
+    0 ≤ deterministicConfidenceRadius b δ n := by
+  exact mul_nonneg hb (Real.sqrt_nonneg _)
+
+lemma sampleConfidenceRadius_nonneg
+    {b δ : ℝ} (hb : 0 ≤ b) :
+    0 ≤ sampleConfidenceRadius b δ n := by
+  exact mul_nonneg hb (Real.sqrt_nonneg _)
+
+lemma exp_neg_deterministicConfidenceRadius_sq
+    (hn : 0 < n) {b δ : ℝ}
+    (hb : 0 < b) (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (-deterministicConfidenceRadius b δ n ^ 2 * n /
+        (2 * b ^ 2)).exp = δ := by
+  have h := mul_exp_neg_confidenceRadius_sq
+    hn (κ := 1) (b := b) (δ := δ) zero_lt_one hb hδ hδ_one
+  simpa [deterministicConfidenceRadius] using h
+
+lemma two_mul_exp_neg_sampleConfidenceRadius_sq
+    (hn : 0 < n) {b δ : ℝ}
+    (hb : 0 < b) (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    2 * (-sampleConfidenceRadius b δ n ^ 2 * n /
+        (2 * b ^ 2)).exp = δ := by
+  apply mul_exp_neg_confidenceRadius_sq
+    hn (κ := 2) (b := b) (δ := δ) (by norm_num) hb hδ
+  linarith
+
+/--
+Countable-class confidence bound from an upper bound `C` on expected
+Rademacher complexity:
+
+`Pr{UDₙ ≥ 2 C + b √(2 log(1/δ)/n)} ≤ δ`.
+-/
+theorem uniform_deviation_tail_bound_countable_of_rademacher_le_delta
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H] [Countable H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C δ : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hC : rademacherComplexity n F μ X ≤ C)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * C + deterministicConfidenceRadius b δ n ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  calc
+    _ ≤ (-deterministicConfidenceRadius b δ n ^ 2 * n /
+          (2 * b ^ 2)).exp :=
+      uniform_deviation_tail_bound_countable_of_rademacher_le
+        (μ := μ) F hF_meas X hX hb hF_bound hC
+        (deterministicConfidenceRadius_nonneg hb.le)
+    _ = δ :=
+      exp_neg_deterministicConfidenceRadius_sq hn hb hδ hδ_one
+
+/--
+Countable-class confidence bound from a uniform fixed-sample upper bound on
+empirical Rademacher complexity.
+-/
+theorem uniform_deviation_tail_bound_countable_of_empirical_le_delta
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H] [Countable H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C δ : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * C + deterministicConfidenceRadius b δ n ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  apply uniform_deviation_tail_bound_countable_of_rademacher_le_delta
+    (μ := μ) hn F hF_meas X hX hb hF_bound _ hδ hδ_one
+  exact rademacherComplexity_le_of_empirical_le_countable
+    (fun h ↦ (hF_meas h).comp hX) hb.le hF_bound hC
+
+/--
+Countable-class sample-dependent confidence bound:
+
+`Pr{UDₙ ≥ 2 C(S) + 3 b √(2 log(2/δ)/n)} ≤ δ`.
+-/
+theorem uniform_deviation_tail_bound_countable_of_sample_empirical_le_delta
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H] [Countable H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    (C : (Fin n → 𝒳) → ℝ)
+    {b δ : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C S)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * C (X ∘ S) + 3 * sampleConfidenceRadius b δ n ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  calc
+    _ ≤ 2 * (-sampleConfidenceRadius b δ n ^ 2 * n /
+          (2 * b ^ 2)).exp :=
+      uniform_deviation_tail_bound_countable_of_sample_empirical_le
+        (μ := μ) F hF_meas X hX C hb hF_bound hC
+        (sampleConfidenceRadius_nonneg hb.le)
+    _ = δ :=
+      two_mul_exp_neg_sampleConfidenceRadius_sq hn hb hδ hδ_one
+
+/--
+Separable-class confidence bound from an upper bound `C` on expected
+Rademacher complexity.
+-/
+theorem uniform_deviation_tail_bound_separable_of_rademacher_le_delta
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C δ : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hC : rademacherComplexity n F μ X ≤ C)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * C + deterministicConfidenceRadius b δ n ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  calc
+    _ ≤ (-deterministicConfidenceRadius b δ n ^ 2 * n /
+          (2 * b ^ 2)).exp :=
+      uniform_deviation_tail_bound_separable_of_rademacher_le
+        (μ := μ) F hF_meas X hX hb hF_bound hF_cont hC
+        (deterministicConfidenceRadius_nonneg hb.le)
+    _ = δ :=
+      exp_neg_deterministicConfidenceRadius_sq hn hb hδ hδ_one
+
+/--
+Confidence-parameter form of the deterministic-threshold separable-class
+generalization bound.
+
+The displayed radius unfolds to
+`b * √(2 * log (1 / δ) / n)`.
+-/
+theorem uniform_deviation_tail_bound_separable_of_empirical_le_delta
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C δ : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * C + b * Real.sqrt (2 * Real.log (1 / δ) / n) ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  simpa [deterministicConfidenceRadius, confidenceRadius] using
+    uniform_deviation_tail_bound_separable_of_rademacher_le_delta
+      (μ := μ) hn F hF_meas X hX hb hF_bound hF_cont
+      (rademacherComplexity_le_of_empirical_le_separable
+        F X (fun h ↦ (hF_meas h).comp hX) hb.le hF_bound hF_cont hC)
+      hδ hδ_one
+
+/--
+Confidence-parameter form of the sample-dependent separable-class
+generalization bound.
+
+The concentration radius unfolds to
+`b * √(2 * log (2 / δ) / n)` because the proof uses a union bound.
+-/
+theorem uniform_deviation_tail_bound_separable_of_sample_empirical_le_delta
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    (C : (Fin n → 𝒳) → ℝ)
+    {b δ : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C S)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * C (X ∘ S) +
+          3 * (b * Real.sqrt (2 * Real.log (2 / δ) / n)) ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  have htail :=
+    uniform_deviation_tail_bound_separable_of_sample_empirical_le
+      (μ := μ) F hF_meas X hX C hb hF_bound hF_cont hC
+      (sampleConfidenceRadius_nonneg (n := n) (δ := δ) hb.le)
+  calc
+    _ = (μⁿ {S : Fin n → Ω |
+        2 * C (X ∘ S) + 3 * sampleConfidenceRadius b δ n ≤
+          uniformDeviation n F μ X (X ∘ S)}).toReal := by
+      simp only [sampleConfidenceRadius, confidenceRadius]
+    _ ≤ 2 * (-sampleConfidenceRadius b δ n ^ 2 * n /
+          (2 * b ^ 2)).exp := htail
+    _ = δ :=
+      two_mul_exp_neg_sampleConfidenceRadius_sq hn hb hδ hδ_one
+
+end


### PR DESCRIPTION
Twelve declarations ported from `auto-res/lean-rademacher` at **`bc33376`** in a new
module, `UniformDeviation/Confidence.lean`.

This completes appendix C-3's foundation block (01–06). As C-3 puts it, once 06 lands
the route from any fixed-sample uniform bound into a generalization bound is in place.

## What the module does

It restates the `ε`-tail bounds of `UniformDeviation/Bounds.lean` in terms of a failure
probability `0 < δ ≤ 1`.

| Declaration | |
|---|---|
| `deterministicConfidenceRadius` | the radius for a bound known before seeing the sample |
| `sampleConfidenceRadius` | the sample-dependent radius |
| `deterministicConfidenceRadius_nonneg`, `sampleConfidenceRadius_nonneg` | both are nonnegative |
| `exp_neg_deterministicConfidenceRadius_sq` | the exponential estimate inverting the tail |
| `two_mul_exp_neg_sampleConfidenceRadius_sq` | its two-sided counterpart |
| `uniform_deviation_tail_bound_countable_of_rademacher_le_delta` | |
| `uniform_deviation_tail_bound_countable_of_empirical_le_delta` | |
| `uniform_deviation_tail_bound_countable_of_sample_empirical_le_delta` | |
| `uniform_deviation_tail_bound_separable_of_rademacher_le_delta` | |
| `uniform_deviation_tail_bound_separable_of_empirical_le_delta` | |
| `uniform_deviation_tail_bound_separable_of_sample_empirical_le_delta` | |

The six `_delta` bounds are countable and separable, each in the three forms that differ
in whether the caller controls the Rademacher complexity, the empirical complexity, or a
sample-dependent bound.

## Provenance against `bc33376`

All twelve declarations are byte-identical to their upstream originals, and nothing from
`Generalization/Confidence.lean` is left behind.

**No v4.33 repair was needed.** The only edits to upstream text are the two import lines,
rewritten through the §0.3 mapping, and the module docstring.

That docstring named `FoML.Generalization.Countable` and `FoML.Generalization.Separable`
— modules that do not exist here, since §0.3 maps both onto the single
`UniformDeviation/Bounds.lean`. It now names the StatsMLlib module. Worth stating
because §0.2 requires paths to be read through the mapping, and a docstring pointing at
a nonexistent module is exactly the kind of thing that survives a port unnoticed.

## Verification

- `lake build` green across all 8802 jobs, changed files touched first so they really
  rebuild, and **no warnings** in the build output.
- `import StatsMLlib.LearningTheory.UniformDeviation.Confidence` type-checks standalone.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- `rg -n 'FoML' StatsMLlib/LearningTheory/UniformDeviation/Confidence.lean` — nothing.
- `FILE_TREE.md` counts cross-checked against the real tree: 96 modules, `LearningTheory` 15.
- 245 added lines, 12 declarations — inside the C-1 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
