### PR TITLE
Add Hilbert, ℓ₂ linear and feature-map kernel predictor classes

### DIFF
--- a/FILE_TREE.md
+++ b/FILE_TREE.md
@@ -1,21 +1,21 @@
 # StatsMLlib file tree
 
 This document presents the public Lean source tree after the Mathlib-style subject refactor.
-`StatsMLlib/` contains 96 Lean modules under eight layer-one directories and no root-level Lean
+`StatsMLlib/` contains 98 Lean modules under eight layer-one directories and no root-level Lean
 files. A filesystem path such as `StatsMLlib/Probability/Process/Dudley.lean` corresponds to the Lean
 module `StatsMLlib.Probability.Process.Dudley`.
 
 | Layer | Modules |
 | --- | ---: |
 | `Analysis` | 5 |
-| `LearningTheory` | 15 |
+| `LearningTheory` | 17 |
 | `LinearAlgebra` | 5 |
 | `MeasureTheory` | 3 |
 | `Order` | 1 |
 | `Probability` | 44 |
 | `Statistics` | 21 |
 | `Topology` | 2 |
-| **Total** | **96** |
+| **Total** | **98** |
 
 ```text
 StatsMLlib/
@@ -33,9 +33,11 @@ StatsMLlib/
 │   │   ├── FunctionClass.lean
 │   │   └── Metric.lean
 │   ├── FunctionClass/
-│   │   └── LinearPredictor/
-│   │       ├── L1.lean
-│   │       └── L2.lean
+│   │   ├── LinearPredictor/
+│   │   │   ├── L1.lean
+│   │   │   └── L2.lean
+│   │   ├── HilbertPredictor.lean
+│   │   └── KernelPredictor.lean
 │   ├── Rademacher/
 │   │   ├── Complexity.lean
 │   │   ├── Defs.lean

--- a/StatsMLlib/LearningTheory/FunctionClass/HilbertPredictor.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/HilbertPredictor.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import Mathlib.Analysis.InnerProductSpace.Basic
+import StatsMLlib.LearningTheory.Rademacher.Signs
+
+/-!
+# Linear predictors on a real inner-product space
+
+This module contains the dimension-free argument underlying the Rademacher
+estimate for Euclidean linear classes and feature-map kernel classes.  The
+fixed-sample theorem requires an inner-product space, but neither completeness
+nor finite dimensionality.
+-/
+
+noncomputable section
+
+universe u
+
+open Real
+
+variable {n : ℕ}
+variable {H : Type u} [NormedAddCommGroup H] [InnerProductSpace ℝ H]
+
+local notation "⟪" x ", " y "⟫" => @inner ℝ _ _ x y
+
+/-- Linear prediction by a weight in a closed ball of a real inner-product space. -/
+noncomputable def hilbertPredictor
+    {Λ : ℝ} (w : Metric.closedBall (0 : H) Λ) (x : H) : ℝ :=
+  ⟪(w : H), x⟫
+
+/-- Continuity of a Hilbert predictor in its weight. -/
+lemma continuous_hilbertPredictor_weight
+    {Λ : ℝ} (x : H) :
+    Continuous fun w : Metric.closedBall (0 : H) Λ ↦
+      hilbertPredictor w x := by
+  unfold hilbertPredictor
+  fun_prop
+
+/-- Continuity of a Hilbert predictor in its input. -/
+lemma continuous_hilbertPredictor_input
+    {Λ : ℝ} (w : Metric.closedBall (0 : H) Λ) :
+    Continuous fun x : H ↦ hilbertPredictor w x := by
+  unfold hilbertPredictor
+  fun_prop
+
+/-- Cauchy--Schwarz together with the weight-radius constraint. -/
+lemma abs_hilbertPredictor_le
+    {Λ : ℝ}
+    (w : Metric.closedBall (0 : H) Λ) (x : H) :
+    |hilbertPredictor w x| ≤ Λ * ‖x‖ := by
+  calc
+    |hilbertPredictor w x| ≤ ‖(w : H)‖ * ‖x‖ :=
+      abs_real_inner_le_norm (w : H) x
+    _ ≤ Λ * ‖x‖ := by
+      gcongr
+      exact mem_closedBall_zero_iff.mp w.property
+
+private lemma rademacher_sum_norm_sq_average
+    (Y : Fin n → H) :
+    (Fintype.card (Signs n) : ℝ)⁻¹ *
+        ∑ σ : Signs n, ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2 =
+      ∑ k : Fin n, ‖Y k‖ ^ 2 := by
+  let A : Signs n → Fin n → Fin n → ℝ :=
+    fun σ k l ↦ (σ k : ℝ) * (σ l : ℝ) * ⟪Y k, Y l⟫
+  have hexpand : ∀ σ : Signs n,
+      ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2 =
+        ∑ k : Fin n, ∑ l : Fin n, A σ k l := by
+    intro σ
+    calc
+      ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2 =
+          ⟪∑ k : Fin n, (σ k : ℝ) • Y k,
+            ∑ l : Fin n, (σ l : ℝ) • Y l⟫ := by
+        symm
+        exact real_inner_self_eq_norm_sq _
+      _ = ∑ k : Fin n,
+          ⟪(σ k : ℝ) • Y k,
+            ∑ l : Fin n, (σ l : ℝ) • Y l⟫ := by
+        rw [sum_inner]
+      _ = ∑ k : Fin n, ∑ l : Fin n,
+          ⟪(σ k : ℝ) • Y k, (σ l : ℝ) • Y l⟫ := by
+        apply Finset.sum_congr rfl
+        intro k _
+        rw [inner_sum]
+      _ = ∑ k : Fin n, ∑ l : Fin n, A σ k l := by
+        apply Finset.sum_congr rfl
+        intro k _
+        apply Finset.sum_congr rfl
+        intro l _
+        simp only [A, real_inner_smul_left, real_inner_smul_right]
+        ring
+  have hsign : ∀ k l : Fin n,
+      ∑ σ : Signs n, (σ k : ℝ) * (σ l : ℝ) =
+        if k = l then (Fintype.card (Signs n) : ℝ) else 0 := by
+    intro k l
+    by_cases hkl : k = l
+    · subst l
+      have hdiag :
+          ∑ σ : Signs n, (σ k : ℝ) * (σ k : ℝ) =
+            (Fintype.card (Signs n) : ℝ) := by
+        calc
+          ∑ σ : Signs n, (σ k : ℝ) * (σ k : ℝ) =
+              ∑ _σ : Signs n, (1 : ℝ) := by
+            apply Finset.sum_congr rfl
+            intro σ _
+            rw [← pow_two]
+            calc
+              (σ k : ℝ) ^ 2 = |(σ k : ℝ)| ^ 2 := (sq_abs _).symm
+              _ = 1 := by rw [abs_sigma]; norm_num
+          _ = Fintype.card (Signs n) := by simp
+      simpa only [if_true] using hdiag
+    · simpa [hkl] using rademacher_orthogonality n k l hkl
+  calc
+    (Fintype.card (Signs n) : ℝ)⁻¹ *
+        ∑ σ : Signs n, ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2 =
+        (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ σ : Signs n, ∑ k : Fin n, ∑ l : Fin n, A σ k l := by
+      apply congrArg
+      exact Finset.sum_congr rfl fun σ _ ↦ hexpand σ
+    _ = (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ k : Fin n, ∑ l : Fin n, ∑ σ : Signs n, A σ k l := by
+      congr 1
+      rw [Finset.sum_comm]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [Finset.sum_comm]
+    _ = (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ k : Fin n, ∑ l : Fin n,
+            (if k = l then (Fintype.card (Signs n) : ℝ) else 0) *
+              ⟪Y k, Y l⟫ := by
+      congr 1
+      apply Finset.sum_congr rfl
+      intro k _
+      apply Finset.sum_congr rfl
+      intro l _
+      simp only [A]
+      rw [← Finset.sum_mul]
+      rw [hsign k l]
+    _ = (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ((Fintype.card (Signs n) : ℝ) *
+            ∑ k : Fin n, ‖Y k‖ ^ 2) := by
+      apply congrArg
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [Finset.sum_eq_single k]
+      · simp
+      · intro l _ hlk
+        simp [Ne.symm hlk]
+      · simp
+    _ = ∑ k : Fin n, ‖Y k‖ ^ 2 := by simp
+
+private lemma rademacher_sum_norm_average_le
+    (Y : Fin n → H) :
+    (Fintype.card (Signs n) : ℝ)⁻¹ *
+        ∑ σ : Signs n, ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ≤
+      Real.sqrt (∑ k : Fin n, ‖Y k‖ ^ 2) := by
+  have hmean :
+      (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ σ : Signs n, ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ≤
+        Real.sqrt
+          ((Fintype.card (Signs n) : ℝ)⁻¹ *
+            ∑ σ : Signs n, ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2) := by
+    apply le_sqrt_of_sq_le
+    let f : Signs n → ℝ := fun _ ↦ 1
+    let g : Signs n → ℝ := fun σ ↦
+      ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ *
+        (Fintype.card (Signs n) : ℝ)⁻¹
+    suffices
+        (∑ σ : Signs n, f σ * g σ) ^ 2 ≤
+          (∑ σ : Signs n, f σ ^ 2) *
+            ∑ σ : Signs n, g σ ^ 2 from by
+      dsimp only [f, g] at this
+      simp only [one_mul, one_pow, Finset.sum_const, Finset.card_univ,
+        nsmul_eq_mul, mul_one] at this
+      have p :
+          (Fintype.card (Signs n) : ℝ)⁻¹ *
+              ∑ σ : Signs n,
+                ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ =
+            ∑ σ : Signs n,
+              ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ *
+                (Fintype.card (Signs n) : ℝ)⁻¹ := by
+        rw [mul_comm, Finset.sum_mul]
+      have q :
+          (Fintype.card (Signs n) : ℝ) *
+              ∑ σ : Signs n,
+                (‖∑ k : Fin n, (σ k : ℝ) • Y k‖ *
+                  (Fintype.card (Signs n) : ℝ)⁻¹) ^ 2 =
+            (Fintype.card (Signs n) : ℝ)⁻¹ *
+              ∑ σ : Signs n,
+                ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2 := by
+        calc
+          _ = (Fintype.card (Signs n) : ℝ) *
+              ∑ σ : Signs n,
+                (‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2 *
+                  ((Fintype.card (Signs n) : ℝ)⁻¹) ^ 2) := by
+            congr 2
+            ext σ
+            ring
+          _ = (Fintype.card (Signs n) : ℝ) *
+              ((∑ σ : Signs n,
+                  ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2) *
+                ((Fintype.card (Signs n) : ℝ)⁻¹) ^ 2) := by
+            congr 1
+            rw [Finset.sum_mul]
+          _ = _ := by
+            have hcard :
+                (Fintype.card (Signs n) : ℝ) ≠ 0 := by
+              rw [Signs.card]
+              positivity
+            field_simp [hcard]
+      rw [p, ← q]
+      exact this
+    exact Finset.sum_mul_sq_le_sq_mul_sq
+      (s := (Finset.univ : Finset (Signs n))) f g
+  calc
+    _ ≤ Real.sqrt
+        ((Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ σ : Signs n, ‖∑ k : Fin n, (σ k : ℝ) • Y k‖ ^ 2) :=
+      hmean
+    _ = Real.sqrt (∑ k : Fin n, ‖Y k‖ ^ 2) := by
+      rw [rademacher_sum_norm_sq_average Y]
+
+/--
+Dimension-free, sample-dependent empirical Rademacher estimate for the full
+closed ball of Hilbert predictors:
+
+`Rhatₙ ≤ Λ / n * sqrt (∑ₖ ‖Sₖ‖²)`.
+
+This fixed-sample result needs only a real inner-product space.  In particular,
+completeness is not used.
+-/
+theorem hilbertPredictor_empiricalRademacherComplexity_le
+    (Λ : ℝ) (hΛ : 0 ≤ Λ) (S : Fin n → H) :
+    empiricalRademacherComplexity n
+        (hilbertPredictor :
+          Metric.closedBall (0 : H) Λ → H → ℝ) S ≤
+      Λ * (n : ℝ)⁻¹ *
+        Real.sqrt (∑ k : Fin n, ‖S k‖ ^ 2) := by
+  let : Nonempty (Metric.closedBall (0 : H) Λ) :=
+    (Metric.nonempty_closedBall.mpr hΛ).to_subtype
+  calc
+    empiricalRademacherComplexity n
+        (hilbertPredictor :
+          Metric.closedBall (0 : H) Λ → H → ℝ) S =
+        (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ σ : Signs n, ⨆ w : Metric.closedBall (0 : H) Λ,
+            |(n : ℝ)⁻¹ *
+              ∑ k : Fin n, (σ k : ℝ) * ⟪(w : H), S k⟫| := rfl
+    _ ≤ (Fintype.card (Signs n) : ℝ)⁻¹ *
+          ∑ σ : Signs n,
+            (n : ℝ)⁻¹ * (Λ *
+              ‖∑ k : Fin n, (σ k : ℝ) • S k‖) := by
+      gcongr with σ
+      apply ciSup_le
+      intro w
+      rw [abs_mul, abs_of_nonneg (inv_nonneg.mpr (Nat.cast_nonneg n))]
+      have hinner :
+          ∑ k : Fin n, (σ k : ℝ) * ⟪(w : H), S k⟫ =
+            ⟪(w : H), ∑ k : Fin n, (σ k : ℝ) • S k⟫ := by
+        rw [inner_sum]
+        apply Finset.sum_congr rfl
+        intro k _
+        rw [real_inner_smul_right]
+      rw [hinner]
+      gcongr
+      exact abs_hilbertPredictor_le w
+        (∑ k : Fin n, (σ k : ℝ) • S k)
+    _ = Λ * (n : ℝ)⁻¹ *
+          ((Fintype.card (Signs n) : ℝ)⁻¹ *
+            ∑ σ : Signs n,
+              ‖∑ k : Fin n, (σ k : ℝ) • S k‖) := by
+      rw [← Finset.mul_sum]
+      simp_rw [← mul_assoc]
+      rw [← Finset.mul_sum]
+      ring
+    _ ≤ Λ * (n : ℝ)⁻¹ *
+          Real.sqrt (∑ k : Fin n, ‖S k‖ ^ 2) := by
+      gcongr
+      exact rademacher_sum_norm_average_le S
+
+end

--- a/StatsMLlib/LearningTheory/FunctionClass/KernelPredictor.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/KernelPredictor.lean
@@ -1,0 +1,351 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import StatsMLlib.LearningTheory.FunctionClass.HilbertPredictor
+import StatsMLlib.LearningTheory.UniformDeviation.Confidence
+
+/-!
+# Feature-map kernels and RKHS predictor bounds
+
+Mathlib does not currently provide a construction of the RKHS associated with
+an arbitrary positive-semidefinite kernel.  This module therefore starts with
+a feature map `Φ : 𝒳 → H` into a real Hilbert space and uses the induced kernel
+
+`K(x,y) = ⟪Φ x, Φ y⟫`.
+
+This is exactly the representation used in the proof of Mohri, Rostamizadeh,
+and Talwalkar, *Foundations of Machine Learning*, Theorem 6.12.
+-/
+
+noncomputable section
+
+universe u v
+
+open Real
+
+variable {n : ℕ}
+variable {𝒳 : Type u}
+variable {H : Type v} [NormedAddCommGroup H] [InnerProductSpace ℝ H]
+
+local notation "⟪" x ", " y "⟫" => @inner ℝ _ _ x y
+
+/-- The kernel induced by a feature map into a real inner-product space. -/
+noncomputable def kernelOfFeatureMap (Φ : 𝒳 → H) (x y : 𝒳) : ℝ :=
+  ⟪Φ x, Φ y⟫
+
+/-- The diagonal of a feature-map kernel is the squared feature norm. -/
+@[simp]
+lemma kernelOfFeatureMap_self
+    (Φ : 𝒳 → H) (x : 𝒳) :
+    kernelOfFeatureMap Φ x x = ‖Φ x‖ ^ 2 := by
+  exact real_inner_self_eq_norm_sq _
+
+/--
+A feature-map kernel is positive semidefinite: every finite Gram quadratic
+form is nonnegative.
+-/
+theorem kernelOfFeatureMap_positiveSemidefinite
+    (Φ : 𝒳 → H) {m : ℕ} (x : Fin m → 𝒳) (a : Fin m → ℝ) :
+    0 ≤ ∑ i : Fin m, ∑ j : Fin m,
+      a i * a j * kernelOfFeatureMap Φ (x i) (x j) := by
+  have hgram :
+      ∑ i : Fin m, ∑ j : Fin m,
+          a i * a j * kernelOfFeatureMap Φ (x i) (x j) =
+        ‖∑ i : Fin m, a i • Φ (x i)‖ ^ 2 := by
+    calc
+      ∑ i : Fin m, ∑ j : Fin m,
+          a i * a j * kernelOfFeatureMap Φ (x i) (x j) =
+          ∑ i : Fin m, ∑ j : Fin m,
+            ⟪a i • Φ (x i), a j • Φ (x j)⟫ := by
+        apply Finset.sum_congr rfl
+        intro i _
+        apply Finset.sum_congr rfl
+        intro j _
+        simp only [kernelOfFeatureMap, real_inner_smul_left,
+          real_inner_smul_right]
+        ring
+      _ = ⟪∑ i : Fin m, a i • Φ (x i),
+          ∑ j : Fin m, a j • Φ (x j)⟫ := by
+        rw [sum_inner]
+        apply Finset.sum_congr rfl
+        intro i _
+        rw [inner_sum]
+      _ = ‖∑ i : Fin m, a i • Φ (x i)‖ ^ 2 :=
+        real_inner_self_eq_norm_sq _
+  rw [hgram]
+  positivity
+
+/-- The diagonal kernel trace of a sample. -/
+noncomputable def kernelTrace
+    (Φ : 𝒳 → H) (S : Fin n → 𝒳) : ℝ :=
+  ∑ k : Fin n, kernelOfFeatureMap Φ (S k) (S k)
+
+@[simp]
+lemma kernelTrace_eq_sum_norm_sq
+    (Φ : 𝒳 → H) (S : Fin n → 𝒳) :
+    kernelTrace Φ S = ∑ k : Fin n, ‖Φ (S k)‖ ^ 2 := by
+  simp [kernelTrace]
+
+/-- Prediction by a bounded Hilbert-space weight after applying a feature map. -/
+noncomputable def rkhsPredictor
+    (Φ : 𝒳 → H) {Λ : ℝ}
+    (w : Metric.closedBall (0 : H) Λ) (x : 𝒳) : ℝ :=
+  hilbertPredictor w (Φ x)
+
+/-- Continuity of the feature-map predictor in its weight. -/
+lemma continuous_rkhsPredictor_weight
+    (Φ : 𝒳 → H) {Λ : ℝ} (x : 𝒳) :
+    Continuous fun w : Metric.closedBall (0 : H) Λ ↦
+      rkhsPredictor Φ w x :=
+  continuous_hilbertPredictor_weight (Φ x)
+
+/-- Measurability in the input follows from measurability of the feature map. -/
+lemma measurable_rkhsPredictor_input
+    [MeasurableSpace 𝒳] [MeasurableSpace H] [BorelSpace H]
+    (Φ : 𝒳 → H) (hΦ : Measurable Φ) {Λ : ℝ}
+    (w : Metric.closedBall (0 : H) Λ) :
+    Measurable fun x ↦ rkhsPredictor Φ w x :=
+  (continuous_hilbertPredictor_input w).measurable.comp hΦ
+
+/-- A diagonal kernel bound implies the corresponding feature-norm bound. -/
+lemma norm_featureMap_le_of_kernel_self_le
+    (Φ : 𝒳 → H) {r : ℝ} (hr : 0 ≤ r) {x : 𝒳}
+    (hx : kernelOfFeatureMap Φ x x ≤ r ^ 2) :
+    ‖Φ x‖ ≤ r := by
+  rw [kernelOfFeatureMap_self] at hx
+  exact (sq_le_sq₀ (norm_nonneg _) hr).mp hx
+
+/-- Pointwise boundedness obtained from the weight and kernel-diagonal bounds. -/
+lemma abs_rkhsPredictor_le
+    (Φ : 𝒳 → H) {Λ r : ℝ} (hΛ : 0 ≤ Λ) (hr : 0 ≤ r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (w : Metric.closedBall (0 : H) Λ) (x : 𝒳) :
+    |rkhsPredictor Φ w x| ≤ r * Λ := by
+  calc
+    |rkhsPredictor Φ w x| ≤ Λ * ‖Φ x‖ :=
+      abs_hilbertPredictor_le w (Φ x)
+    _ ≤ Λ * r := by
+      gcongr
+      exact norm_featureMap_le_of_kernel_self_le Φ hr (hdiag x)
+    _ = r * Λ := mul_comm _ _
+
+/--
+Mohri, Rostamizadeh, and Talwalkar, Theorem 6.12, in kernel-trace form:
+
+`Rhatₙ ≤ Λ / n * sqrt (∑ₖ K(Sₖ,Sₖ))`.
+
+The feature space is assumed complete here to match the Hilbert/RKHS
+interpretation.  The underlying dimension-free theorem in
+`FoML.Model.HilbertPredictor` does not require completeness.
+-/
+theorem rkhs_empiricalRademacherComplexity_le_kernelTrace
+    [CompleteSpace H]
+    (Φ : 𝒳 → H) (Λ : ℝ) (hΛ : 0 ≤ Λ) (S : Fin n → 𝒳) :
+    empiricalRademacherComplexity n
+        (rkhsPredictor Φ :
+          Metric.closedBall (0 : H) Λ → 𝒳 → ℝ) S ≤
+      Λ * (n : ℝ)⁻¹ * Real.sqrt (kernelTrace Φ S) := by
+  change empiricalRademacherComplexity n
+      (fun w x ↦ hilbertPredictor w (Φ x)) S ≤
+    Λ * (n : ℝ)⁻¹ * Real.sqrt (kernelTrace Φ S)
+  rw [empiricalRademacherComplexity_comp]
+  simpa using
+    hilbertPredictor_empiricalRademacherComplexity_le
+      Λ hΛ (Φ ∘ S)
+
+/--
+Uniform-diagonal form of Mohri et al., Theorem 6.12:
+
+if `K(x,x) ≤ r²`, then `Rhatₙ ≤ r Λ / √n`.
+-/
+theorem rkhs_empiricalRademacherComplexity_le
+    [CompleteSpace H]
+    (Φ : 𝒳 → H) (Λ r : ℝ) (hΛ : 0 ≤ Λ) (hr : 0 ≤ r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (S : Fin n → 𝒳) :
+    empiricalRademacherComplexity n
+        (rkhsPredictor Φ :
+          Metric.closedBall (0 : H) Λ → 𝒳 → ℝ) S ≤
+      r * Λ / Real.sqrt (n : ℝ) := by
+  calc
+    empiricalRademacherComplexity n
+        (rkhsPredictor Φ :
+          Metric.closedBall (0 : H) Λ → 𝒳 → ℝ) S ≤
+        Λ * (n : ℝ)⁻¹ * Real.sqrt (kernelTrace Φ S) :=
+      rkhs_empiricalRademacherComplexity_le_kernelTrace Φ Λ hΛ S
+    _ ≤ Λ * (n : ℝ)⁻¹ *
+        Real.sqrt (∑ _k : Fin n, r ^ 2) := by
+      rw [kernelTrace_eq_sum_norm_sq]
+      gcongr with k
+      exact norm_featureMap_le_of_kernel_self_le Φ hr (hdiag (S k))
+    _ = Λ * (n : ℝ)⁻¹ * Real.sqrt ((n : ℝ) * r ^ 2) := by simp
+    _ = Λ * (n : ℝ)⁻¹ * (Real.sqrt (n : ℝ) * r) := by
+      rw [Real.sqrt_mul (Nat.cast_nonneg n), Real.sqrt_sq_eq_abs,
+        abs_of_nonneg hr]
+    _ = r * Λ / Real.sqrt (n : ℝ) := by
+      by_cases hn : 0 < n
+      · have hsqrt : Real.sqrt (n : ℝ) ≠ 0 := by positivity
+        field_simp [hsqrt]
+        rw [Real.sq_sqrt (Nat.cast_nonneg n)]
+      · have hn0 : n = 0 := Nat.eq_zero_of_not_pos hn
+        subst n
+        simp
+
+end
+
+-- Upstream splits the fixed-sample kernel estimates and the generalization bounds
+-- into two modules with separate preambles; §0.3 merges them into this one. The
+-- section below carries the second module's context verbatim, including its own
+-- universe assignment, which differs from the one above.
+noncomputable section Generalization
+
+universe u v w
+
+open MeasureTheory ProbabilityTheory Real TopologicalSpace
+open scoped ENNReal
+
+variable {n : ℕ}
+variable {Ω : Type u} [MeasurableSpace Ω]
+variable {𝒳 : Type v} [MeasurableSpace 𝒳]
+variable {H : Type w} [NormedAddCommGroup H] [InnerProductSpace ℝ H]
+  [CompleteSpace H] [MeasurableSpace H] [BorelSpace H] [SeparableSpace H]
+variable {μ : Measure Ω}
+
+set_option hygiene false in
+local notation "μⁿ" => Measure.pi (fun _ ↦ μ)
+/--
+Expected Rademacher estimate for the bounded feature-map class:
+
+`Rₙ ≤ r Λ / √n`.
+-/
+theorem rkhs_rademacherComplexity_le
+    [IsProbabilityMeasure μ]
+    (Φ : 𝒳 → H) (hΦ : Measurable Φ)
+    (Λ r : ℝ) (hΛ : 0 ≤ Λ) (hr : 0 ≤ r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (X : Ω → 𝒳) (hX : Measurable X) :
+    rademacherComplexity n
+        (rkhsPredictor Φ :
+          Metric.closedBall (0 : H) Λ → 𝒳 → ℝ) μ X ≤
+      r * Λ / Real.sqrt (n : ℝ) := by
+  let : Nonempty (Metric.closedBall (0 : H) Λ) :=
+    (Metric.nonempty_closedBall.mpr hΛ).to_subtype
+  apply rademacherComplexity_le_of_empirical_le_separable
+    (F := rkhsPredictor Φ) (X := X)
+  · intro w
+    exact (measurable_rkhsPredictor_input Φ hΦ w).comp hX
+  · exact mul_nonneg hr hΛ
+  · exact fun w x ↦ abs_rkhsPredictor_le Φ hΛ hr hdiag w x
+  · exact continuous_rkhsPredictor_weight Φ
+  · exact rkhs_empiricalRademacherComplexity_le Φ Λ r hΛ hr hdiag
+
+/--
+Expected uniform-deviation estimate:
+
+`E[UDₙ] ≤ 2 r Λ / √n`.
+-/
+theorem rkhs_uniformDeviation_expectation_le
+    [Nonempty 𝒳] [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (Φ : 𝒳 → H) (hΦ : Measurable Φ)
+    (Λ r : ℝ) (hΛ : 0 ≤ Λ) (hr : 0 ≤ r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (X : Ω → 𝒳) (hX : Measurable X) :
+    μⁿ[fun S : Fin n → Ω ↦
+      uniformDeviation n
+        (rkhsPredictor Φ :
+          Metric.closedBall (0 : H) Λ → 𝒳 → ℝ)
+        μ X (X ∘ S)] ≤
+      2 * (r * Λ / Real.sqrt (n : ℝ)) := by
+  let : Nonempty (Metric.closedBall (0 : H) Λ) :=
+    (Metric.nonempty_closedBall.mpr hΛ).to_subtype
+  apply uniform_deviation_expectation_le_of_empirical_le_separable
+    (F := rkhsPredictor Φ) hn
+  · exact fun w ↦ measurable_rkhsPredictor_input Φ hΦ w
+  · exact hX
+  · exact mul_nonneg hr hΛ
+  · exact fun w x ↦ abs_rkhsPredictor_le Φ hΛ hr hdiag w x
+  · exact continuous_rkhsPredictor_weight Φ
+  · exact rkhs_empiricalRademacherComplexity_le Φ Λ r hΛ hr hdiag
+
+/--
+Deterministic confidence bound obtained from the diagonal estimate:
+
+`Pr{UDₙ ≥ 2 rΛ/√n + rΛ sqrt(2 log(1/δ)/n)} ≤ δ`.
+
+In the notation of Mohri et al., Theorem 6.12, Lean's `Λ` is the RKHS weight
+radius and `r²` bounds `K(x,x)`.  `CompleteSpace H` records that the feature
+space is Hilbert, `SeparableSpace H` is needed only for the uncountable-class
+generalization bridge, `hΦ` supplies measurability of every predictor, and
+`hdiag` supplies both the Rademacher and concentration radii.
+-/
+theorem rkhs_uniformDeviation_tail_bound_delta
+    [Nonempty 𝒳] [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (Φ : 𝒳 → H) (hΦ : Measurable Φ)
+    (Λ r : ℝ) (hΛ : 0 < Λ) (hr : 0 < r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * (r * Λ / Real.sqrt (n : ℝ)) +
+          (r * Λ) * Real.sqrt (2 * Real.log (1 / δ) / n) ≤
+        uniformDeviation n
+          (rkhsPredictor Φ :
+            Metric.closedBall (0 : H) Λ → 𝒳 → ℝ)
+          μ X (X ∘ S)}).toReal ≤ δ := by
+  let : Nonempty (Metric.closedBall (0 : H) Λ) :=
+    (Metric.nonempty_closedBall.mpr hΛ.le).to_subtype
+  apply uniform_deviation_tail_bound_separable_of_empirical_le_delta
+    (μ := μ) hn (F := rkhsPredictor Φ)
+  · exact fun w ↦ measurable_rkhsPredictor_input Φ hΦ w
+  · exact hX
+  · exact mul_pos hr hΛ
+  · exact fun w x ↦ abs_rkhsPredictor_le Φ hΛ.le hr.le hdiag w x
+  · exact continuous_rkhsPredictor_weight Φ
+  · exact rkhs_empiricalRademacherComplexity_le
+      Φ Λ r hΛ.le hr.le hdiag
+  · exact hδ
+  · exact hδ_one
+
+/--
+Sample-dependent confidence bound retaining the observed kernel trace:
+
+`Pr{UDₙ ≥ 2Λ/n sqrt(trace K_S)
+    + 3rΛ sqrt(2 log(2/δ)/n)} ≤ δ`.
+-/
+theorem rkhs_uniformDeviation_tail_bound_kernelTrace_delta
+    [Nonempty 𝒳] [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (Φ : 𝒳 → H) (hΦ : Measurable Φ)
+    (Λ r : ℝ) (hΛ : 0 < Λ) (hr : 0 < r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * (Λ * (n : ℝ)⁻¹ * Real.sqrt (kernelTrace Φ (X ∘ S))) +
+          3 * ((r * Λ) *
+            Real.sqrt (2 * Real.log (2 / δ) / n)) ≤
+        uniformDeviation n
+          (rkhsPredictor Φ :
+            Metric.closedBall (0 : H) Λ → 𝒳 → ℝ)
+          μ X (X ∘ S)}).toReal ≤ δ := by
+  let : Nonempty (Metric.closedBall (0 : H) Λ) :=
+    (Metric.nonempty_closedBall.mpr hΛ.le).to_subtype
+  exact uniform_deviation_tail_bound_separable_of_sample_empirical_le_delta
+    (μ := μ) hn
+    (rkhsPredictor Φ :
+      Metric.closedBall (0 : H) Λ → 𝒳 → ℝ)
+    (fun w ↦ measurable_rkhsPredictor_input Φ hΦ w)
+    X hX
+    (fun S ↦ Λ * (n : ℝ)⁻¹ * Real.sqrt (kernelTrace Φ S))
+    (mul_pos hr hΛ)
+    (fun w x ↦ abs_rkhsPredictor_le Φ hΛ.le hr.le hdiag w x)
+    (continuous_rkhsPredictor_weight Φ)
+    (rkhs_empiricalRademacherComplexity_le_kernelTrace Φ Λ hΛ.le)
+    hδ hδ_one
+
+
+end Generalization

--- a/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L2.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L2.lean
@@ -6,6 +6,9 @@ Authors: Kei Tsukamoto, Kazumi Kasaura, Naoto Onda, Yuma Mizuno, Sho Sonoda
 import StatsMLlib.LearningTheory.Rademacher.Symmetrization
 import StatsMLlib.LearningTheory.Rademacher.Signs
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import StatsMLlib.LearningTheory.FunctionClass.HilbertPredictor
+import StatsMLlib.LearningTheory.UniformDeviation.Confidence
+import StatsMLlib.LearningTheory.Rademacher.Reindex
 
 /-!
 # Rademacher Complexity of L2 Linear Predictors
@@ -374,3 +377,302 @@ theorem linear_predictor_l2_bound
       n (fun (i : ι) a ↦ ⟪((Subtype.val ∘ w') i), a⟫) (Subtype.val ∘ Y') ≤
     X * W / √(n : ℝ) := by
   exact linear_predictor_l2_bound' (d := d) (n := n) (W := W) (X := X) hx hw Y' w'
+
+/-- Linear prediction with both the weight and input restricted to closed Euclidean balls. -/
+noncomputable def linearPredictorL2
+    {d : ℕ} {W X : ℝ}
+    (w : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W)
+    (x : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) : ℝ :=
+  ⟪(w : EuclideanSpace ℝ (Fin d)), (x : EuclideanSpace ℝ (Fin d))⟫
+
+lemma continuous_linearPredictorL2_weight
+    {d : ℕ} {W X : ℝ}
+    (x : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) :
+    Continuous fun w : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W ↦
+      linearPredictorL2 w x := by
+  unfold linearPredictorL2
+  fun_prop
+
+lemma continuous_linearPredictorL2_input
+    {d : ℕ} {W X : ℝ}
+    (w : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W) :
+    Continuous fun x : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X ↦
+      linearPredictorL2 w x := by
+  unfold linearPredictorL2
+  fun_prop
+
+/-- Pointwise boundedness needed by the generalization theorem. -/
+lemma abs_linearPredictorL2_le
+    {d : ℕ} {W X : ℝ} (hW : 0 ≤ W)
+    (w : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W)
+    (x : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) :
+    |linearPredictorL2 w x| ≤ X * W := by
+  calc
+    |linearPredictorL2 w x|
+        ≤ ‖(w : EuclideanSpace ℝ (Fin d))‖ *
+            ‖(x : EuclideanSpace ℝ (Fin d))‖ := by
+          exact abs_real_inner_le_norm
+            (w : EuclideanSpace ℝ (Fin d)) (x : EuclideanSpace ℝ (Fin d))
+    _ ≤ W * X := by
+      apply mul_le_mul
+      · exact mem_closedBall_zero_iff.mp w.property
+      · exact mem_closedBall_zero_iff.mp x.property
+      · exact norm_nonneg (x : EuclideanSpace ℝ (Fin d))
+      · exact hW
+    _ = X * W := mul_comm W X
+
+/--
+Sample-dependent empirical Rademacher-complexity bound for the full class of
+`ℓ₂`-bounded linear predictors.
+-/
+theorem linear_predictor_l2_empirical_bound_of_sample
+    (d n : ℕ) (W X : ℝ) (hW : 0 ≤ W)
+    (S : Fin n → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) :
+    empiricalRademacherComplexity n
+        (linearPredictorL2 :
+          Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+            Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ) S
+      ≤ W * (n : ℝ)⁻¹ *
+        Real.sqrt
+          (∑ k : Fin n, ‖(S k : EuclideanSpace ℝ (Fin d))‖ ^ 2) := by
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W) :=
+    (Metric.nonempty_closedBall.mpr hW).to_subtype
+  change empiricalRademacherComplexity n
+    (fun (w : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W)
+        (x : Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) ↦
+      ⟪(w : EuclideanSpace ℝ (Fin d)), (x : EuclideanSpace ℝ (Fin d))⟫) S
+      ≤ W * (n : ℝ)⁻¹ *
+        Real.sqrt
+          (∑ k : Fin n, ‖(S k : EuclideanSpace ℝ (Fin d))‖ ^ 2)
+  rw [empiricalRademacherComplexity_comp]
+  exact hilbertPredictor_empiricalRademacherComplexity_le
+    (H := EuclideanSpace ℝ (Fin d)) W hW (Subtype.val ∘ S)
+
+/--
+Empirical Rademacher-complexity bound for the full class of `ℓ₂`-bounded
+linear predictors on an `ℓ₂`-bounded input space.
+-/
+theorem linear_predictor_l2_empirical_bound
+    (d n : ℕ) (W X : ℝ) (hX : 0 ≤ X) (hW : 0 ≤ W)
+    (S : Fin n → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) :
+    empiricalRademacherComplexity n
+        (linearPredictorL2 :
+          Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+            Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ) S
+      ≤ X * W / Real.sqrt (n : ℝ) := by
+  calc
+    empiricalRademacherComplexity n
+        (linearPredictorL2 :
+          Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+            Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ) S ≤
+        W * (n : ℝ)⁻¹ *
+          Real.sqrt
+            (∑ k : Fin n,
+              ‖(S k : EuclideanSpace ℝ (Fin d))‖ ^ 2) :=
+      linear_predictor_l2_empirical_bound_of_sample d n W X hW S
+    _ ≤ W * (n : ℝ)⁻¹ * Real.sqrt (∑ _k : Fin n, X ^ 2) := by
+      gcongr with k
+      exact mem_closedBall_zero_iff.mp (S k).property
+    _ = W * (n : ℝ)⁻¹ * Real.sqrt ((n : ℝ) * X ^ 2) := by simp
+    _ = W * (n : ℝ)⁻¹ * (Real.sqrt (n : ℝ) * X) := by
+      rw [Real.sqrt_mul (Nat.cast_nonneg n), Real.sqrt_sq_eq_abs,
+        abs_of_nonneg hX]
+    _ = X * W / Real.sqrt (n : ℝ) := by
+      by_cases hn : 0 < n
+      · have hsqrt : Real.sqrt (n : ℝ) ≠ 0 := by positivity
+        field_simp [hsqrt]
+        rw [Real.sq_sqrt (Nat.cast_nonneg n)]
+      · have hn0 : n = 0 := Nat.eq_zero_of_not_pos hn
+        subst n
+        simp
+
+-- Upstream keeps the fixed-sample estimates and the generalization bounds in two
+-- modules with separate preambles; §0.3 merges them here. This section supplies what
+-- the second one needs: the sample index implicit rather than explicit, the
+-- probability space, and the product-measure notation.
+section Generalization
+
+universe u
+
+open MeasureTheory ProbabilityTheory
+
+variable {n : ℕ}
+variable {Ω : Type u} [MeasurableSpace Ω] {μ : Measure Ω}
+
+set_option hygiene false in
+local notation "μⁿ" => Measure.pi (fun _ ↦ μ)
+
+/--
+Expected Rademacher-complexity bound for the full `ℓ₂`-bounded linear class:
+
+`Rₙ(F₂,W; μ) ≤ X * W / √n`.
+-/
+theorem linear_predictor_l2_rademacher_complexity_bound
+    [IsProbabilityMeasure μ]
+    (d : ℕ) (W X : ℝ) (hX : 0 ≤ X) (hW : 0 ≤ W)
+    (Z : Ω → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X)
+    (hZ : Measurable Z) :
+    rademacherComplexity n
+        (linearPredictorL2 :
+          Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+            Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ)
+        μ Z
+      ≤ X * W / Real.sqrt (n : ℝ) := by
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W) :=
+    (Metric.nonempty_closedBall.mpr hW).to_subtype
+  apply rademacherComplexity_le_of_empirical_le_separable
+    (F := linearPredictorL2) (X := Z)
+  · intro w
+    exact (continuous_linearPredictorL2_input w).measurable.comp hZ
+  · exact mul_nonneg hX hW
+  · exact fun w x ↦ abs_linearPredictorL2_le hW w x
+  · exact continuous_linearPredictorL2_weight
+  · exact linear_predictor_l2_empirical_bound d n W X hX hW
+
+/--
+Expected uniform-deviation bound for the full `ℓ₂`-bounded linear class:
+
+`𝔼[UDₙ] ≤ 2 * X * W / √n`.
+-/
+theorem linear_predictor_l2_uniform_deviation_expectation_bound
+    [IsProbabilityMeasure μ]
+    (d : ℕ) (W X : ℝ) (hn : 0 < n) (hX : 0 ≤ X) (hW : 0 ≤ W)
+    (Z : Ω → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X)
+    (hZ : Measurable Z) :
+    μⁿ[fun S : Fin n → Ω ↦
+      uniformDeviation n
+        (linearPredictorL2 :
+          Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+            Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ)
+        μ Z (Z ∘ S)]
+      ≤ 2 * (X * W / Real.sqrt (n : ℝ)) := by
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W) :=
+    (Metric.nonempty_closedBall.mpr hW).to_subtype
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) :=
+    (Metric.nonempty_closedBall.mpr hX).to_subtype
+  apply uniform_deviation_expectation_le_of_empirical_le_separable
+    (F := linearPredictorL2) hn
+  · exact fun w ↦ (continuous_linearPredictorL2_input w).measurable
+  · exact hZ
+  · exact mul_nonneg hX hW
+  · exact fun w x ↦ abs_linearPredictorL2_le hW w x
+  · exact continuous_linearPredictorL2_weight
+  · exact linear_predictor_l2_empirical_bound d n W X hX hW
+
+/--
+High-probability `ε`-form bound for the full `ℓ₂` linear class:
+
+`Pr{UDₙ ≥ 2 X W / √n + ε} ≤ exp (-n ε² / (2 (X W)²))`.
+-/
+theorem linear_predictor_l2_uniform_deviation_tail_bound
+    [IsProbabilityMeasure μ]
+    (d : ℕ) (W X : ℝ) (_hn : 0 < n) (hX : 0 < X) (hW : 0 < W)
+    (Z : Ω → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X)
+    (hZ : Measurable Z) {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S |
+      2 * (X * W / Real.sqrt (n : ℝ)) + ε ≤
+        uniformDeviation n
+          (linearPredictorL2 :
+            Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+              Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ)
+          μ Z (Z ∘ S)}).toReal
+      ≤ (-ε ^ 2 * n / (2 * (X * W) ^ 2)).exp := by
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W) :=
+    (Metric.nonempty_closedBall.mpr hW.le).to_subtype
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) :=
+    (Metric.nonempty_closedBall.mpr hX.le).to_subtype
+  apply uniform_deviation_tail_bound_separable_of_empirical_le
+    (F := linearPredictorL2)
+  · exact fun w ↦ (continuous_linearPredictorL2_input w).measurable
+  · exact hZ
+  · exact mul_pos hX hW
+  · exact fun w x ↦ abs_linearPredictorL2_le hW.le w x
+  · exact continuous_linearPredictorL2_weight
+  · exact linear_predictor_l2_empirical_bound d n W X hX.le hW.le
+  · exact hε
+
+/--
+End-to-end confidence bound for the full `ℓ₂`-bounded linear class:
+
+`Pr{UDₙ ≥ 2 X W / √n + X W √(2 log(1/δ)/n)} ≤ δ`.
+
+The first term is the Rademacher-complexity contribution and the second is
+the concentration contribution.
+-/
+theorem linear_predictor_l2_uniform_deviation_tail_bound_delta
+    [IsProbabilityMeasure μ]
+    (d : ℕ) (W X : ℝ) (hn : 0 < n) (hX : 0 < X) (hW : 0 < W)
+    (Z : Ω → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X)
+    (hZ : Measurable Z) {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * (X * W / Real.sqrt (n : ℝ)) +
+          (X * W) * Real.sqrt (2 * Real.log (1 / δ) / n) ≤
+        uniformDeviation n
+          (linearPredictorL2 :
+            Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+              Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ)
+          μ Z (Z ∘ S)}).toReal ≤ δ := by
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W) :=
+    (Metric.nonempty_closedBall.mpr hW.le).to_subtype
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) :=
+    (Metric.nonempty_closedBall.mpr hX.le).to_subtype
+  apply uniform_deviation_tail_bound_separable_of_empirical_le_delta
+    (μ := μ) hn (F := linearPredictorL2)
+  · exact fun w ↦ (continuous_linearPredictorL2_input w).measurable
+  · exact hZ
+  · exact mul_pos hX hW
+  · exact fun w x ↦ abs_linearPredictorL2_le hW.le w x
+  · exact continuous_linearPredictorL2_weight
+  · exact linear_predictor_l2_empirical_bound d n W X hX.le hW.le
+  · exact hδ
+  · exact hδ_one
+
+/--
+Sample-dependent end-to-end confidence bound for the full `ℓ₂` class:
+
+`Pr{UDₙ ≥ (2W/n) √(∑ₖ ‖Zₖ‖²)
+    + 3 X W √(2 log(2/δ)/n)} ≤ δ`.
+
+The empirical norm sum is retained instead of being replaced by `n X²`.
+-/
+theorem linear_predictor_l2_uniform_deviation_tail_bound_of_sample_delta
+    [IsProbabilityMeasure μ]
+    (d : ℕ) (W X : ℝ) (hn : 0 < n) (hX : 0 < X) (hW : 0 < W)
+    (Z : Ω → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X)
+    (hZ : Measurable Z) {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 *
+          (W * (n : ℝ)⁻¹ *
+            Real.sqrt
+              (∑ k : Fin n,
+                ‖(Z (S k) : EuclideanSpace ℝ (Fin d))‖ ^ 2)) +
+        3 * ((X * W) * Real.sqrt (2 * Real.log (2 / δ) / n)) ≤
+          uniformDeviation n
+            (linearPredictorL2 :
+              Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+                Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ)
+            μ Z (Z ∘ S)}).toReal ≤ δ := by
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W) :=
+    (Metric.nonempty_closedBall.mpr hW.le).to_subtype
+  let : Nonempty (Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X) :=
+    (Metric.nonempty_closedBall.mpr hX.le).to_subtype
+  have htail :=
+    uniform_deviation_tail_bound_separable_of_sample_empirical_le_delta
+      (μ := μ) (n := n) hn
+      (linearPredictorL2 :
+        Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+          Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ)
+      (fun w ↦ (continuous_linearPredictorL2_input w).measurable)
+      Z hZ
+      (fun S ↦
+        W * (n : ℝ)⁻¹ *
+          Real.sqrt
+            (∑ k : Fin n, ‖(S k : EuclideanSpace ℝ (Fin d))‖ ^ 2))
+      (mul_pos hX hW)
+      (fun w x ↦ abs_linearPredictorL2_le hW.le w x)
+      continuous_linearPredictorL2_weight
+      (linear_predictor_l2_empirical_bound_of_sample d n W X hW.le)
+      hδ hδ_one
+  simpa only [Function.comp_apply] using htail
+
+end Generalization


### PR DESCRIPTION
**No design decision in this PR.** Straight port of upstream's proofs; every departure
from upstream text is listed below.

Thirty-four declarations from `auto-res/lean-rademacher` at **`bc33376`**, covering
appendix C-3's PRs **09, 10 and 13** in one change.

## Why the three are together

They are one subject: a predictor class given by an inner product against a bounded
weight, plus its two specializations. Upstream's own import graph says so —
`Model/LinearPredictorL2.lean` and `Model/RKHS.lean` both import
`Model/HilbertPredictor.lean`, and the `ℓ₂` bound is proved as the finite-dimensional
case of the Hilbert one.

C-1's 200–600 lines and 10–20 declarations are a 目安, and C-1 itself says
「レビューの実質的な対象は宣言数と設計判断であり行数ではない」. This PR is 937 lines
and 34 declarations, over that guideline, and stated here as C-1 asks. Splitting it
into three would have meant three passes over the same subject with the same context
reloaded each time.

## What is added

**`FunctionClass/HilbertPredictor.lean`** (new, 7 declarations) — the general case:
the predictor `⟪w, x⟫` for `w` in a ball of radius `Λ`, its continuity in each
argument, and the empirical Rademacher bound `W / n · √(∑ ‖xₖ‖²)`.

**`FunctionClass/LinearPredictor/L2.lean`** (+11) — the finite-dimensional case:
`linearPredictorL2`, continuity, the absolute bound, the fixed-sample empirical bounds
in sample-dependent and uniform form, and then the generalization route — expected
Rademacher complexity, expected uniform deviation, and tail bounds in both `ε` and `δ`
form, the last retaining the observed sample.

**`FunctionClass/KernelPredictor.lean`** (new, 16 declarations) — the feature-map case.
Mathlib has no RKHS construction for an arbitrary positive-semidefinite kernel, so
upstream starts from a feature map `Φ : 𝒳 → H` into a real Hilbert space and uses the
induced kernel `K(x,y) = ⟪Φ x, Φ y⟫`, following Mohri, Rostamizadeh and Talwalkar,
*Foundations of Machine Learning*, Theorem 6.12.

## Departures from upstream text

**1. Merged preambles.** §0.3 maps each of upstream's *pairs* — a fixed-sample module
and a generalization module — onto a single StatsMLlib module. The two upstream files
have different preambles, so `L2.lean` and `KernelPredictor.lean` each gain a
`section Generalization` carrying the second one's context, with a source comment
saying why. `KernelPredictor.lean`'s section also restates the universe assignment,
which differs between the two upstream files.

**2. Three repairs.**

`letI` → `let` on `Prop` goals, 14 occurrences: v4.33's `linter.style.haveILetI`, and
the build must be warning-free.

`simpa only [if_pos rfl]` → `simpa only [if_true]` in `HilbertPredictor.lean`: at v4.33
the goal keeps its `if True then … else 0` shape.

In `L2.lean`, a `simpa` that can no longer see through an unapplied definition:

```diff
-  simpa only [Function.comp_apply] using
-    (hilbertPredictor_empiricalRademacherComplexity_le
-      (H := EuclideanSpace ℝ (Fin d)) W hW (Subtype.val ∘ S))
+  exact hilbertPredictor_empiricalRademacherComplexity_le
+    (H := EuclideanSpace ℝ (Fin d)) W hW (Subtype.val ∘ S)
```

The goal reads `empiricalRademacherComplexity n (fun w ↦ inner ℝ ↑w) …` while the lemma
gives `… n hilbertPredictor …`. Adding `hilbertPredictor` to the simp set does not help
— it appears unapplied, as a function argument, and `simp [f]` rewrites `f a`. The two
are definitionally equal, so `exact` closes it.

## Provenance against `bc33376`

`upstream-only = 0` on all three pairs: nothing from the five upstream modules is left
behind.

## Verification

- `lake build` green across all 8804 jobs, changed files touched first so they really
  rebuild, and **no warnings** in the build output.
- Both new modules type-check from a standalone `import`.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- `FILE_TREE.md` cross-checked against the real tree: 98 modules, `LearningTheory` 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
