### PR TITLE
Remove the duplicate nonemptiness hypothesis from Massart's lemma

### DIFF
--- a/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L1.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L1.lean
@@ -155,7 +155,6 @@ theorem linear_predictor_l1_bound'
         have hx := (Y' i).2 jb.1
         rw [show (Subtype.val ∘ Y') i = (Y' i).1 by rfl]
         simpa [coordSigned, abs_mul, abs_boolSign] using hx)
-      hs
 
   -- (2) bound the sup term by X∞/sqrt(n)
   have hsup :

--- a/StatsMLlib/LearningTheory/Rademacher/Dudley.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Dudley.lean
@@ -835,7 +835,6 @@ private lemma massart_bound_for_increment_term (c_pos : 0 < c) (h' : TotallyBoun
           have : Real.sqrt (i (S j) ^ 2) ≤ Real.sqrt (∑ x : Fin m, i (S x) ^ 2) := by
             exact Real.sqrt_le_sqrt hsq
           simpa [Real.sqrt_sq_eq_abs] using this
-      · exact incrementFinset_nonempty c_pos h' n j
     · have : √(2 * Real.log ((Set.Finite.toFinset (finite_incrementSet c_pos h' n j)).card)) = √(2 * Real.log ↑(incrementFinset c_pos h' n j).card) := by
         apply congrArg
         apply congrArg

--- a/StatsMLlib/LearningTheory/Rademacher/Massart.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Massart.lean
@@ -172,14 +172,13 @@ theorem massart_lemma_pmf.sign_mean_zero {Z : Type v} {m : ℕ}
 
 lemma massart_lemma_pmf
     (f : Finset ι) (hs : f.Nonempty) (m_pos : 0 < m)
-    (C : ℝ) (hC : ∀ i ∈ f, ∀ j, |F i (S j)| ≤ C)
-    (hsR : f.Nonempty) :
+    (C : ℝ) (hC : ∀ i ∈ f, ∀ j, |F i (S j)| ≤ C) :
     empiricalRademacherComplexity_pmf_without_abs m (F_on (ι:=ι) (Z:=Z) F f) S
       ≤ (Finset.sup' f hs fun j => Real.sqrt (∑ i : Fin m,
             ((m : ℝ)⁻¹ * |F j (S i)|) ^ 2)) * Real.sqrt (2 * Real.log f.card) := by
     have hbridge :
         empiricalRademacherComplexity_pmf_without_abs m (F_on (ι:=ι) (Z:=Z) F f) S
-          = ∫ σ, Finset.sup' f hsR
+          = ∫ σ, Finset.sup' f hs
                 (fun j => MassartNotation.X (F:=F) (S:=S) (m:=m) (ι:=ι) j σ) ∂(signVecPMF m).toMeasure := by
       dsimp [empiricalRademacherComplexity_pmf_without_abs]
       dsimp [MassartNotation.X]
@@ -262,7 +261,7 @@ lemma massart_lemma_pmf
       (n := f.card)
       (s := (Finset.univ : Finset (Fin m)))
       (s' := f)
-      hsR
+      hs
       rfl
       (X := MassartNotation.X (F:=F) (S:=S) (m:=m) (ι:=ι))
       (Y := MassartNotation.Y (F:=F) (S:=S) (m:=m) (ι:=ι))


### PR DESCRIPTION
**Refactor only. Zero declarations added, removed or renamed.** Plan §13.8.
Three files, 3 insertions and 6 deletions.

## What changed

`massart_lemma_pmf` took the nonemptiness of the index finset **twice**:

```lean
lemma massart_lemma_pmf
    (f : Finset ι) (hs : f.Nonempty) (m_pos : 0 < m)
    (C : ℝ) (hC : ∀ i ∈ f, ∀ j, |F i (S j)| ≤ C)
    (hsR : f.Nonempty) :                              -- ← the same hypothesis again
```

`hs` is load-bearing — the statement needs it for `Finset.sup' f hs` — while `hsR`
appeared only inside the proof, twice. Upstream states the lemma with `hs` alone and
threads it through; `hsR` does not exist there at all.

Plan §13.8 lists this:

> Massart の重複する非空性仮定と、最適化 tail 定理の未使用局所仮定を除く。

The binder is dropped and its two uses become `hs`. Both call sites lose the extra
argument: `LinearPredictor/L1.lean` passed it positionally, `Rademacher/Dudley.lean`
as a trailing bullet.

## Why now, and why on its own

The next PR ports the `ℓ₁` linear predictor from
`Model/LinearPredictorL1.lean`, and its proofs call this lemma in upstream's
single-hypothesis form. Against the current signature they fail with

```
has type      Finset.univ.Nonempty → empiricalRademacherComplexity_pmf_without_abs … ≤ …
but is expected to have type
              empiricalRademacherComplexity_pmf_without_abs … ≤ …
```

— the leftover binder showing up as an implication.

There are only three call sites in the library, and one of them is in
`Rademacher/Dudley.lean`, which the Dudley port will rewrite next. Doing this before
that port keeps the two changes from colliding.

It is separate from the port because C-1 forbids mixing an addition with a rewrite of
existing working proofs, and requires a refactoring PR to state that no declaration is
added or removed. Both hold, checked mechanically: the declaration lists of all three
modules are identical to `main`.

## Verification

- `lake build` green across all 8804 jobs, changed files touched first so they really
  rebuild, and no warnings in the build output.
- Declaration lists of `Massart.lean`, `L1.lean` and `Dudley.lean` compared against
  `main` — all identical.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
