### PR TITLE
Add empirical risk minimization and bridge least squares to it

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@ The current second-level organization is:
 ```text
 StatsMLlib/
 ├── Analysis/{MetricEntropy,NormedSpace}
-├── LearningTheory/{EmpiricalProcess,FunctionClass,Rademacher,UniformDeviation}
+├── LearningTheory/{EmpiricalProcess,EmpiricalRiskMinimization,FunctionClass,Rademacher,UniformDeviation}
 ├── LinearAlgebra/Matrix
 ├── MeasureTheory/{Function,Integral,Measure}
 ├── Order

--- a/FILE_TREE.md
+++ b/FILE_TREE.md
@@ -1,21 +1,21 @@
 # StatsMLlib file tree
 
 This document presents the public Lean source tree after the Mathlib-style subject refactor.
-`StatsMLlib/` contains 100 Lean modules under eight layer-one directories and no root-level Lean
+`StatsMLlib/` contains 102 Lean modules under eight layer-one directories and no root-level Lean
 files. A filesystem path such as `StatsMLlib/Probability/Process/Dudley.lean` corresponds to the Lean
 module `StatsMLlib.Probability.Process.Dudley`.
 
 | Layer | Modules |
 | --- | ---: |
 | `Analysis` | 5 |
-| `LearningTheory` | 19 |
+| `LearningTheory` | 21 |
 | `LinearAlgebra` | 5 |
 | `MeasureTheory` | 3 |
 | `Order` | 1 |
 | `Probability` | 44 |
 | `Statistics` | 21 |
 | `Topology` | 2 |
-| **Total** | **100** |
+| **Total** | **102** |
 
 ```text
 StatsMLlib/
@@ -29,6 +29,9 @@ StatsMLlib/
 │   │       └── L1.lean
 │   └── FiniteSample.lean
 ├── LearningTheory/
+│   ├── EmpiricalRiskMinimization/
+│   │   ├── Basic.lean
+│   │   └── Defs.lean
 │   ├── EmpiricalProcess/
 │   │   ├── FunctionClass.lean
 │   │   └── Metric.lean

--- a/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Basic.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Basic.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import StatsMLlib.LearningTheory.EmpiricalRiskMinimization.Defs
+import StatsMLlib.Analysis.FiniteSample
+
+/-!
+# Deterministic oracle inequalities for empirical risk minimization
+
+The central result is the deterministic implication
+
+`R(hhat) - R(hstar) ≤ 2 D + η`
+
+whenever `hhat` is an `η`-approximate ERM and every empirical/population risk
+discrepancy is at most `D`.  The uniform-deviation version is then a small
+order-theoretic bridge.
+-/
+
+noncomputable section
+
+universe u v w
+
+open MeasureTheory ProbabilityTheory Real
+
+variable {n : ℕ}
+variable {Ω : Type u} [MeasurableSpace Ω] {H : Type v} {𝒵 : Type w}
+variable {μ : Measure Ω}
+
+@[simp]
+lemma isApproxERM_zero_iff_isERM
+    (ℓ : H → 𝒵 → ℝ) (S : Fin n → 𝒵) (hhat : H) :
+    IsApproxERM 0 n ℓ S hhat ↔ IsERM n ℓ S hhat := by
+  simp [IsApproxERM, IsERM]
+
+lemma IsERM.isApproxERM
+    {ℓ : H → 𝒵 → ℝ} {S : Fin n → 𝒵} {hhat : H}
+    (hERM : IsERM n ℓ S hhat) :
+    IsApproxERM 0 n ℓ S hhat :=
+  (isApproxERM_zero_iff_isERM ℓ S hhat).2 hERM
+
+/--
+Deterministic oracle inequality from a pointwise deviation estimate:
+
+`R(hhat) - R(hstar) ≤ 2 D + η`.
+-/
+theorem IsApproxERM.excessRisk_le
+    {ℓ : H → 𝒵 → ℝ} {Z : Ω → 𝒵} {S : Fin n → 𝒵}
+    {hhat hstar : H} {η D : ℝ}
+    (hERM : IsApproxERM η n ℓ S hhat)
+    (hdev : ∀ h, riskDeviation n ℓ μ Z S h ≤ D) :
+    excessRisk ℓ μ Z hhat hstar ≤ 2 * D + η := by
+  have hhatDev := abs_le.mp (hdev hhat)
+  have hstarDev := abs_le.mp (hdev hstar)
+  have hopt := hERM hstar
+  dsimp only [excessRisk]
+  linarith
+
+/--
+Exact-ERM specialization of `IsApproxERM.excessRisk_le`.
+-/
+theorem IsERM.excessRisk_le
+    {ℓ : H → 𝒵 → ℝ} {Z : Ω → 𝒵} {S : Fin n → 𝒵}
+    {hhat hstar : H} {D : ℝ}
+    (hERM : IsERM n ℓ S hhat)
+    (hdev : ∀ h, riskDeviation n ℓ μ Z S h ≤ D) :
+    excessRisk ℓ μ Z hhat hstar ≤ 2 * D := by
+  simpa using hERM.isApproxERM.excessRisk_le (μ := μ) hdev
+
+/--
+Uniform deviation is definitionally the supremum of `riskDeviation`.
+-/
+lemma uniformDeviation_eq_iSup_riskDeviation
+    (ℓ : H → 𝒵 → ℝ) (Z : Ω → 𝒵) (S : Fin n → 𝒵) :
+    uniformDeviation n ℓ μ Z S =
+      ⨆ h, riskDeviation n ℓ μ Z S h :=
+  rfl
+
+/--
+Every pointwise risk discrepancy is at most uniform deviation, provided the
+family of discrepancies is bounded above.
+-/
+lemma riskDeviation_le_uniformDeviation
+    {ℓ : H → 𝒵 → ℝ} {Z : Ω → 𝒵} {S : Fin n → 𝒵}
+    (hbounded :
+      BddAbove (Set.range fun h ↦ riskDeviation n ℓ μ Z S h))
+    (h : H) :
+    riskDeviation n ℓ μ Z S h ≤ uniformDeviation n ℓ μ Z S := by
+  rw [uniformDeviation_eq_iSup_riskDeviation]
+  exact le_ciSup hbounded h
+
+/--
+The deterministic approximate-ERM oracle inequality in terms of uniform
+deviation.
+-/
+theorem IsApproxERM.excessRisk_le_two_mul_uniformDeviation
+    {ℓ : H → 𝒵 → ℝ} {Z : Ω → 𝒵} {S : Fin n → 𝒵}
+    {hhat hstar : H} {η : ℝ}
+    (hERM : IsApproxERM η n ℓ S hhat)
+    (hbounded :
+      BddAbove (Set.range fun h ↦ riskDeviation n ℓ μ Z S h)) :
+    excessRisk ℓ μ Z hhat hstar ≤
+      2 * uniformDeviation n ℓ μ Z S + η :=
+  hERM.excessRisk_le (fun h ↦ riskDeviation_le_uniformDeviation hbounded h)
+
+/--
+The deterministic exact-ERM oracle inequality in terms of uniform deviation.
+-/
+theorem IsERM.excessRisk_le_two_mul_uniformDeviation
+    {ℓ : H → 𝒵 → ℝ} {Z : Ω → 𝒵} {S : Fin n → 𝒵}
+    {hhat hstar : H}
+    (hERM : IsERM n ℓ S hhat)
+    (hbounded :
+      BddAbove (Set.range fun h ↦ riskDeviation n ℓ μ Z S h)) :
+    excessRisk ℓ μ Z hhat hstar ≤
+      2 * uniformDeviation n ℓ μ Z S := by
+  simpa using
+    hERM.isApproxERM.excessRisk_le_two_mul_uniformDeviation
+      (μ := μ) (hstar := hstar) hbounded
+
+/--
+For a probability distribution and a loss bounded in absolute value by `b`,
+each risk discrepancy is at most `2 * b`.
+-/
+lemma riskDeviation_le_two_mul
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    {ℓ : H → 𝒵 → ℝ} {Z : Ω → 𝒵}
+    (hℓ_meas : ∀ h, Measurable (ℓ h ∘ Z))
+    {b : ℝ} (hℓ_bound : ∀ h z, |ℓ h z| ≤ b)
+    (S : Fin n → 𝒵) (h : H) :
+    riskDeviation n ℓ μ Z S h ≤ 2 * b := by
+  have hmean : |populationRisk ℓ μ Z h| ≤ b := by
+    dsimp only [populationRisk]
+    calc
+      |∫ x : Ω, ℓ h (Z x) ∂μ| ≤ ∫ x : Ω, |ℓ h (Z x)| ∂μ :=
+        abs_integral_le_integral_abs
+      _ ≤ ∫ _x : Ω, b ∂μ := by
+        apply integral_mono
+        · constructor
+          · exact (hℓ_meas h).norm.aestronglyMeasurable
+          · apply HasFiniteIntegral.of_mem_Icc
+            filter_upwards
+            intro x
+            exact ⟨abs_nonneg _, hℓ_bound h (Z x)⟩
+        · exact integrable_const b
+        · exact fun x ↦ hℓ_bound h (Z x)
+      _ = b := by simp
+  have hsample : |empiricalRisk n ℓ S h| ≤ b := by
+    exact abs_normalized_fin_sum_le hn (fun _ z ↦ ℓ h z) S
+      (fun _ z ↦ hℓ_bound h z)
+  dsimp only [riskDeviation]
+  calc
+    |empiricalRisk n ℓ S h - populationRisk ℓ μ Z h| ≤
+        |empiricalRisk n ℓ S h| + |populationRisk ℓ μ Z h| :=
+      abs_sub _ _
+    _ ≤ b + b := add_le_add hsample hmean
+    _ = 2 * b := by ring
+
+/--
+Bounded losses make the range of pointwise risk discrepancies bounded above.
+-/
+lemma bddAbove_range_riskDeviation
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    {ℓ : H → 𝒵 → ℝ} {Z : Ω → 𝒵}
+    (hℓ_meas : ∀ h, Measurable (ℓ h ∘ Z))
+    {b : ℝ} (hℓ_bound : ∀ h z, |ℓ h z| ≤ b)
+    (S : Fin n → 𝒵) :
+    BddAbove (Set.range fun h ↦ riskDeviation n ℓ μ Z S h) := by
+  refine ⟨2 * b, ?_⟩
+  rintro _ ⟨h, rfl⟩
+  exact riskDeviation_le_two_mul hn hℓ_meas hℓ_bound S h
+
+end

--- a/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Defs.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Defs.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import StatsMLlib.LearningTheory.Rademacher.Defs
+import StatsMLlib.LearningTheory.UniformDeviation.Defs
+
+/-!
+# Risks, empirical risk minimization, and loss classes
+
+This file defines the basic learning-theoretic objects used by the excess-risk
+bounds.  An empirical risk minimizer is represented by a predicate rather than
+by a chosen `argmin`; consequently, downstream oracle inequalities do not need
+existence or measurability assumptions that are irrelevant to their proofs.
+-/
+
+noncomputable section
+
+universe u v w
+
+open MeasureTheory
+
+variable {Ω : Type u} {H : Type v} {𝒵 : Type w}
+
+/--
+The population risk of `h`:
+
+`populationRisk ℓ μ Z h = ∫ ω, ℓ h (Z ω) ∂μ`.
+-/
+def populationRisk
+    [MeasurableSpace Ω]
+    (ℓ : H → 𝒵 → ℝ) (μ : Measure Ω) (Z : Ω → 𝒵) (h : H) : ℝ :=
+  ∫ ω, ℓ h (Z ω) ∂μ
+
+/--
+The empirical risk of `h` on a sample `S` of size `n`:
+
+`empiricalRisk n ℓ S h = n⁻¹ * ∑ k, ℓ h (S k)`.
+-/
+def empiricalRisk
+    (n : ℕ) (ℓ : H → 𝒵 → ℝ) (S : Fin n → 𝒵) (h : H) : ℝ :=
+  (n : ℝ)⁻¹ * ∑ k : Fin n, ℓ h (S k)
+
+/--
+The excess risk of `h` relative to a comparator `hstar`:
+
+`excessRisk ℓ μ Z h hstar = R(h) - R(hstar)`.
+
+The comparator need not minimize population risk.  This makes deterministic
+oracle inequalities reusable even when existence of a minimizer is handled
+separately.
+-/
+def excessRisk
+    [MeasurableSpace Ω]
+    (ℓ : H → 𝒵 → ℝ) (μ : Measure Ω) (Z : Ω → 𝒵)
+    (h hstar : H) : ℝ :=
+  populationRisk ℓ μ Z h - populationRisk ℓ μ Z hstar
+
+/--
+`hhat` is an empirical risk minimizer for `ℓ` on `S`.
+-/
+def IsERM
+    (n : ℕ) (ℓ : H → 𝒵 → ℝ) (S : Fin n → 𝒵) (hhat : H) : Prop :=
+  ∀ h, empiricalRisk n ℓ S hhat ≤ empiricalRisk n ℓ S h
+
+/--
+`hhat` is an `η`-approximate empirical risk minimizer for `ℓ` on `S`.
+-/
+def IsApproxERM
+    (η : ℝ) (n : ℕ) (ℓ : H → 𝒵 → ℝ)
+    (S : Fin n → 𝒵) (hhat : H) : Prop :=
+  ∀ h, empiricalRisk n ℓ S hhat ≤ empiricalRisk n ℓ S h + η
+
+/--
+`hstar` minimizes population risk over the represented hypothesis class.
+-/
+def IsPopulationRiskMinimizer
+    [MeasurableSpace Ω]
+    (ℓ : H → 𝒵 → ℝ) (μ : Measure Ω) (Z : Ω → 𝒵) (hstar : H) : Prop :=
+  ∀ h, populationRisk ℓ μ Z hstar ≤ populationRisk ℓ μ Z h
+
+/--
+The pointwise discrepancy between empirical and population risk.
+-/
+def riskDeviation
+    [MeasurableSpace Ω]
+    (n : ℕ) (ℓ : H → 𝒵 → ℝ) (μ : Measure Ω) (Z : Ω → 𝒵)
+    (S : Fin n → 𝒵) (h : H) : ℝ :=
+  |empiricalRisk n ℓ S h - populationRisk ℓ μ Z h|
+
+/--
+The supervised loss class induced by predictors `F` and a loss function
+`loss`: `(x, y) ↦ loss (F h x) y`.
+-/
+def supervisedLossClass
+    {𝒳 𝒴 : Type*}
+    (F : H → 𝒳 → ℝ) (loss : ℝ → 𝒴 → ℝ) : H → (𝒳 × 𝒴) → ℝ :=
+  fun h z ↦ loss (F h z.1) z.2
+
+/--
+Center a loss in its prediction argument.  The centered loss vanishes at
+prediction zero and has the same Lipschitz constant as the original loss.
+-/
+def centeredLoss {𝒴 : Type*} (loss : ℝ → 𝒴 → ℝ) : ℝ → 𝒴 → ℝ :=
+  fun u y ↦ loss u y - loss 0 y
+
+@[simp]
+lemma centeredLoss_zero {𝒴 : Type*} (loss : ℝ → 𝒴 → ℝ) (y : 𝒴) :
+    centeredLoss loss 0 y = 0 := by
+  simp [centeredLoss]
+
+lemma centeredLoss_add_base
+    {𝒴 : Type*} (loss : ℝ → 𝒴 → ℝ) (u : ℝ) (y : 𝒴) :
+    centeredLoss loss u y + loss 0 y = loss u y := by
+  simp [centeredLoss]
+
+lemma supervisedLossClass_eq_centered_add_base
+    {𝒳 𝒴 : Type*}
+    (F : H → 𝒳 → ℝ) (loss : ℝ → 𝒴 → ℝ) (h : H) (z : 𝒳 × 𝒴) :
+    supervisedLossClass F loss h z =
+      supervisedLossClass F (centeredLoss loss) h z + loss 0 z.2 := by
+  simp [supervisedLossClass, centeredLoss]
+
+end

--- a/StatsMLlib/Statistics/Regression/LeastSquares/Defs.lean
+++ b/StatsMLlib/Statistics/Regression/LeastSquares/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuanhe Zhang, Jason D. Lee, Fanghui Liu
 -/
 import StatsMLlib.LearningTheory.EmpiricalProcess.Metric
+import StatsMLlib.LearningTheory.EmpiricalRiskMinimization.Defs
 import StatsMLlib.Probability.Gaussian.Basic
 import Mathlib
 
@@ -122,5 +123,28 @@ lemma RegressionModel.sq_σ_pos (M : RegressionModel n X) : 0 < M.σ ^ 2 :=
 /-- σ is non-negative -/
 lemma RegressionModel.σ_nonneg (M : RegressionModel n X) : 0 ≤ M.σ :=
   le_of_lt M.hσ_pos
+
+/-- Least-squares estimation is empirical risk minimisation.
+
+Appendix B-6 of the porting plan keeps `isLeastSquaresEstimator` as the squared-loss
+specialisation and adds `IsERM` as the general predicate; this is the bridge between
+them.
+
+The bridge lives here rather than beside `IsERM` because `ARCHITECTURE.md` puts
+`LearningTheory` below `Statistics` in the import order, so only this side can see both.
+
+Three gaps are closed in the statement. The general predicate quantifies over a whole
+hypothesis type, so the class `F` is used as one via `↥F`. The general predicate
+normalises by `n⁻¹`, which is positive and so preserves the inequality. And the sample
+is a single family of observations, so the pairs `(x k, y k)` are packaged as one. -/
+theorem isLeastSquaresEstimator.isERM {n : ℕ} {y : Fin n → ℝ} {F : Set (X → ℝ)}
+    {x : Fin n → X} {f_hat : X → ℝ} (h : isLeastSquaresEstimator y F x f_hat) :
+    IsERM n (fun f : ↥F ↦ fun p : X × ℝ ↦ (p.2 - (f : X → ℝ) p.1) ^ 2)
+      (fun k ↦ (x k, y k)) ⟨f_hat, h.1⟩ := by
+  intro f
+  have hle : ∑ k : Fin n, (y k - f_hat (x k)) ^ 2 ≤
+      ∑ k : Fin n, (y k - (f : X → ℝ) (x k)) ^ 2 := h.le_of_mem f.2
+  have hn : (0 : ℝ) ≤ (n : ℝ)⁻¹ := by positivity
+  simpa [empiricalRisk] using mul_le_mul_of_nonneg_left hle hn
 
 end LeastSquares


### PR DESCRIPTION
**One design decision, described below: where appendix B-6's bridge goes.**
Appendix C-3's PR 14.

Twenty-three declarations. Twenty-two are ported from `auto-res/lean-rademacher` at
**`bc33376`**; the twenty-third is written, not ported.

## The ported part

**`EmpiricalRiskMinimization/Defs.lean`** (new) — population and empirical risk, excess
risk, `IsERM` and `IsApproxERM`, `IsPopulationRiskMinimizer`, risk deviation, and the
supervised loss class with its centering lemmas.

**`EmpiricalRiskMinimization/Basic.lean`** (new) — the deterministic oracle inequality
and its approximate form.

`upstream-only = 0` on both, and **no v4.33 repair was needed** — the only edits to
upstream text are the import lines.

`ARCHITECTURE.md` gains `EmpiricalRiskMinimization` in its structure diagram, which
appendix C-2 assigns to this PR.

## The design decision: where B-6's bridge lives

Appendix B-6 keeps `isLeastSquaresEstimator` as the squared-loss predicate, adds `IsERM`
as the general one, and asks for one bridging lemma. That lemma has no home in C-3's
target list:

| | module | tier |
|---|---|---|
| `IsERM` | `LearningTheory/EmpiricalRiskMinimization/Defs.lean` | 3 |
| `isLeastSquaresEstimator` | `Statistics/Regression/LeastSquares/Defs.lean` | 4 |

`ARCHITECTURE.md` puts `LearningTheory` **below** `Statistics`, so a lemma naming both
can only live on the Statistics side — and C-3 lists no Statistics file for PR 14. The
placement follows from the layering rule rather than from the plan, so it is called out
here rather than decided quietly.

It is an addition: nothing in `Statistics/Regression/LeastSquares/Defs.lean` changes,
and one import is added.

Unlike everything else in this port, **this lemma is written rather than ported** — both
predicates it connects are StatsMLlib's own, so upstream has nothing to copy.

## What the bridge has to reconcile

```lean
IsERM n ℓ S hhat := ∀ h, empiricalRisk n ℓ S hhat ≤ empiricalRisk n ℓ S h
  where empiricalRisk n ℓ S h = n⁻¹ * ∑ k, ℓ h (S k)

isLeastSquaresEstimator y F x f_hat :=
  f_hat ∈ F ∧ ∀ f ∈ F, ∑ i, (y i - f_hat (x i))^2 ≤ ∑ i, (y i - f (x i))^2
```

Three gaps:

1. `IsERM` quantifies over a whole hypothesis **type**; `isLeastSquaresEstimator` over a
   **subset** `F` and additionally asserts `f_hat ∈ F`. Closed by using `↥F` as the
   hypothesis type, with `h.1` supplying membership.
2. `IsERM` normalises by `n⁻¹`; the least-squares condition is a raw sum. `n⁻¹ ≥ 0`, so
   the inequality is preserved.
3. `IsERM` takes one sample family; least squares takes inputs and responses separately.
   Closed by pairing them as `(x k, y k) : X × ℝ`.

## Verification

- `lake build` green across all 8808 jobs, changed files touched first so they really
  rebuild, and **no warnings** in the build output.
- Both new modules type-check from a standalone `import`.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- Import direction: the bridge respects the tier order, which is the point of putting it
  where it is.
- `FILE_TREE.md` cross-checked against the real tree: 102 modules, `LearningTheory` 21.
- 325 added lines, within the C-1 guideline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
