### PR TITLE
Add the contraction principle and ERM generalization bounds

### DIFF
--- a/FILE_TREE.md
+++ b/FILE_TREE.md
@@ -1,21 +1,21 @@
 # StatsMLlib file tree
 
 This document presents the public Lean source tree after the Mathlib-style subject refactor.
-`StatsMLlib/` contains 102 Lean modules under eight layer-one directories and no root-level Lean
+`StatsMLlib/` contains 105 Lean modules under eight layer-one directories and no root-level Lean
 files. A filesystem path such as `StatsMLlib/Probability/Process/Dudley.lean` corresponds to the Lean
 module `StatsMLlib.Probability.Process.Dudley`.
 
 | Layer | Modules |
 | --- | ---: |
 | `Analysis` | 5 |
-| `LearningTheory` | 21 |
+| `LearningTheory` | 24 |
 | `LinearAlgebra` | 5 |
 | `MeasureTheory` | 3 |
 | `Order` | 1 |
 | `Probability` | 44 |
 | `Statistics` | 21 |
 | `Topology` | 2 |
-| **Total** | **102** |
+| **Total** | **105** |
 
 ```text
 StatsMLlib/
@@ -31,7 +31,9 @@ StatsMLlib/
 ├── LearningTheory/
 │   ├── EmpiricalRiskMinimization/
 │   │   ├── Basic.lean
-│   │   └── Defs.lean
+│   │   ├── Defs.lean
+│   │   ├── Generalization.lean
+│   │   └── KernelPredictor.lean
 │   ├── EmpiricalProcess/
 │   │   ├── FunctionClass.lean
 │   │   └── Metric.lean
@@ -43,6 +45,7 @@ StatsMLlib/
 │   │   └── KernelPredictor.lean
 │   ├── Rademacher/
 │   │   ├── Complexity.lean
+│   │   ├── Contraction.lean
 │   │   ├── Defs.lean
 │   │   ├── Dudley.lean
 │   │   ├── FiniteClass.lean

--- a/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Generalization.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Generalization.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import StatsMLlib.LearningTheory.EmpiricalRiskMinimization.Basic
+import StatsMLlib.LearningTheory.UniformDeviation.Confidence
+
+/-!
+# Excess-risk bounds for empirical risk minimization
+
+This module composes two reusable bridges:
+
+1. an `η`-approximate ERM has excess risk at most
+   `2 * uniformDeviation + η`;
+2. uniform deviation is controlled by expected or observed empirical
+   Rademacher complexity.
+
+No measurability assumption is imposed on the learning rule
+`A : (Fin n → 𝒵) → H`: the probability is interpreted through
+`Measure.real`, hence as an outer probability when the bad event is not known
+to be measurable.
+-/
+
+noncomputable section
+
+universe u v w
+
+open MeasureTheory ProbabilityTheory Real TopologicalSpace
+open scoped ENNReal
+
+variable {n : ℕ}
+variable {Ω : Type u} [MeasurableSpace Ω] {H : Type v} {𝒵 : Type w}
+variable {μ : Measure Ω}
+
+local notation "μⁿ" => Measure.pi (fun _ ↦ μ)
+
+/--
+Expected-complexity excess-risk tail bound for an approximate ERM:
+
+`Pr{R(A(S)) - R(hstar) ≥ 4 C + 2 ε + η}
+  ≤ exp (-n ε² / (2 b²))`.
+-/
+theorem approxERM_excessRisk_tail_bound_separable_of_rademacher_le
+    [MeasurableSpace 𝒵] [Nonempty 𝒵] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (ℓ : H → 𝒵 → ℝ) (hℓ_meas : ∀ h, Measurable (ℓ h))
+    (Z : Ω → 𝒵) (hZ : Measurable Z)
+    {b C η : ℝ} (hb : 0 < b) (hℓ_bound : ∀ h z, |ℓ h z| ≤ b)
+    (hℓ_cont : ∀ z : 𝒵, Continuous fun h ↦ ℓ h z)
+    (A : (Fin n → 𝒵) → H)
+    (hA : ∀ S, IsApproxERM η n ℓ S (A S))
+    (hC : rademacherComplexity n ℓ μ Z ≤ C)
+    (hstar : H) {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S : Fin n → Ω |
+      4 * C + 2 * ε + η ≤
+        excessRisk ℓ μ Z (A (Z ∘ S)) hstar}).toReal ≤
+      (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  calc
+    _ ≤ (μⁿ {S : Fin n → Ω |
+        2 * C + ε ≤ uniformDeviation n ℓ μ Z (Z ∘ S)}).toReal := by
+      apply measureReal_mono (h₂ := measure_ne_top _ _)
+      intro S hbad
+      change 4 * C + 2 * ε + η ≤
+        excessRisk ℓ μ Z (A (Z ∘ S)) hstar at hbad
+      change 2 * C + ε ≤ uniformDeviation n ℓ μ Z (Z ∘ S)
+      have horacle :=
+        (hA (Z ∘ S)).excessRisk_le_two_mul_uniformDeviation
+          (μ := μ) (Z := Z) (hstar := hstar)
+          (bddAbove_range_riskDeviation
+            hn (fun h ↦ (hℓ_meas h).comp hZ) hℓ_bound (Z ∘ S))
+      linarith
+    _ ≤ _ :=
+      uniform_deviation_tail_bound_separable_of_rademacher_le
+        (μ := μ) ℓ hℓ_meas Z hZ hb hℓ_bound hℓ_cont hC hε
+
+/--
+Observed empirical-complexity excess-risk tail bound for an approximate ERM:
+
+`Pr{R(A(S)) - R(hstar) ≥ 4 Rhatₙ(ℓ;S) + 6 ε + η}
+  ≤ 2 exp (-n ε² / (2 b²))`.
+-/
+theorem approxERM_excessRisk_tail_bound_separable_of_empirical_complexity
+    [MeasurableSpace 𝒵] [Nonempty 𝒵] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (ℓ : H → 𝒵 → ℝ) (hℓ_meas : ∀ h, Measurable (ℓ h))
+    (Z : Ω → 𝒵) (hZ : Measurable Z)
+    {b η : ℝ} (hb : 0 < b) (hℓ_bound : ∀ h z, |ℓ h z| ≤ b)
+    (hℓ_cont : ∀ z : 𝒵, Continuous fun h ↦ ℓ h z)
+    (A : (Fin n → 𝒵) → H)
+    (hA : ∀ S, IsApproxERM η n ℓ S (A S))
+    (hstar : H) {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S : Fin n → Ω |
+      4 * empiricalRademacherComplexity n ℓ (Z ∘ S) + 6 * ε + η ≤
+        excessRisk ℓ μ Z (A (Z ∘ S)) hstar}).toReal ≤
+      2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  calc
+    _ ≤ (μⁿ {S : Fin n → Ω |
+        2 * empiricalRademacherComplexity n ℓ (Z ∘ S) + 3 * ε ≤
+          uniformDeviation n ℓ μ Z (Z ∘ S)}).toReal := by
+      apply measureReal_mono (h₂ := measure_ne_top _ _)
+      intro S hbad
+      change
+        4 * empiricalRademacherComplexity n ℓ (Z ∘ S) +
+              6 * ε + η ≤
+          excessRisk ℓ μ Z (A (Z ∘ S)) hstar at hbad
+      change
+        2 * empiricalRademacherComplexity n ℓ (Z ∘ S) + 3 * ε ≤
+          uniformDeviation n ℓ μ Z (Z ∘ S)
+      have horacle :=
+        (hA (Z ∘ S)).excessRisk_le_two_mul_uniformDeviation
+          (μ := μ) (Z := Z) (hstar := hstar)
+          (bddAbove_range_riskDeviation
+            hn (fun h ↦ (hℓ_meas h).comp hZ) hℓ_bound (Z ∘ S))
+      linarith
+    _ ≤ _ :=
+      uniform_deviation_tail_bound_separable_of_empirical_complexity
+        (μ := μ) ℓ hℓ_meas Z hZ hb hℓ_bound hℓ_cont hε
+
+/--
+Confidence-parameter form of the expected-complexity excess-risk bound:
+
+`Pr{R(A(S)) - R(hstar) ≥ 4 C + 2 r(b,δ,n) + η} ≤ δ`.
+-/
+theorem approxERM_excessRisk_tail_bound_separable_of_rademacher_le_delta
+    [MeasurableSpace 𝒵] [Nonempty 𝒵] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (ℓ : H → 𝒵 → ℝ) (hℓ_meas : ∀ h, Measurable (ℓ h))
+    (Z : Ω → 𝒵) (hZ : Measurable Z)
+    {b C η δ : ℝ} (hb : 0 < b) (hℓ_bound : ∀ h z, |ℓ h z| ≤ b)
+    (hℓ_cont : ∀ z : 𝒵, Continuous fun h ↦ ℓ h z)
+    (A : (Fin n → 𝒵) → H)
+    (hA : ∀ S, IsApproxERM η n ℓ S (A S))
+    (hC : rademacherComplexity n ℓ μ Z ≤ C)
+    (hstar : H) (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      4 * C + 2 * deterministicConfidenceRadius b δ n + η ≤
+        excessRisk ℓ μ Z (A (Z ∘ S)) hstar}).toReal ≤ δ := by
+  calc
+    _ ≤ (μⁿ {S : Fin n → Ω |
+        2 * C + deterministicConfidenceRadius b δ n ≤
+          uniformDeviation n ℓ μ Z (Z ∘ S)}).toReal := by
+      apply measureReal_mono (h₂ := measure_ne_top _ _)
+      intro S hbad
+      change
+        4 * C + 2 * deterministicConfidenceRadius b δ n + η ≤
+          excessRisk ℓ μ Z (A (Z ∘ S)) hstar at hbad
+      change
+        2 * C + deterministicConfidenceRadius b δ n ≤
+          uniformDeviation n ℓ μ Z (Z ∘ S)
+      have horacle :=
+        (hA (Z ∘ S)).excessRisk_le_two_mul_uniformDeviation
+          (μ := μ) (Z := Z) (hstar := hstar)
+          (bddAbove_range_riskDeviation
+            hn (fun h ↦ (hℓ_meas h).comp hZ) hℓ_bound (Z ∘ S))
+      linarith
+    _ ≤ δ :=
+      uniform_deviation_tail_bound_separable_of_rademacher_le_delta
+        (μ := μ) hn ℓ hℓ_meas Z hZ hb hℓ_bound hℓ_cont hC hδ hδ_one
+
+/--
+Confidence-parameter form retaining any sample-dependent empirical-complexity
+upper bound `C(S)`:
+
+`Pr{R(A(S)) - R(hstar) ≥ 4 C(S) + 6 r₂(b,δ,n) + η} ≤ δ`.
+-/
+theorem approxERM_excessRisk_tail_bound_separable_of_sample_empirical_le_delta
+    [MeasurableSpace 𝒵] [Nonempty 𝒵] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (ℓ : H → 𝒵 → ℝ) (hℓ_meas : ∀ h, Measurable (ℓ h))
+    (Z : Ω → 𝒵) (hZ : Measurable Z)
+    (C : (Fin n → 𝒵) → ℝ)
+    {b η δ : ℝ} (hb : 0 < b) (hℓ_bound : ∀ h z, |ℓ h z| ≤ b)
+    (hℓ_cont : ∀ z : 𝒵, Continuous fun h ↦ ℓ h z)
+    (A : (Fin n → 𝒵) → H)
+    (hA : ∀ S, IsApproxERM η n ℓ S (A S))
+    (hC : ∀ S, empiricalRademacherComplexity n ℓ S ≤ C S)
+    (hstar : H) (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      4 * C (Z ∘ S) + 6 * sampleConfidenceRadius b δ n + η ≤
+        excessRisk ℓ μ Z (A (Z ∘ S)) hstar}).toReal ≤ δ := by
+  calc
+    _ ≤ (μⁿ {S : Fin n → Ω |
+        2 * C (Z ∘ S) + 3 * sampleConfidenceRadius b δ n ≤
+          uniformDeviation n ℓ μ Z (Z ∘ S)}).toReal := by
+      apply measureReal_mono (h₂ := measure_ne_top _ _)
+      intro S hbad
+      change
+        4 * C (Z ∘ S) + 6 * sampleConfidenceRadius b δ n + η ≤
+          excessRisk ℓ μ Z (A (Z ∘ S)) hstar at hbad
+      change
+        2 * C (Z ∘ S) + 3 * sampleConfidenceRadius b δ n ≤
+          uniformDeviation n ℓ μ Z (Z ∘ S)
+      have horacle :=
+        (hA (Z ∘ S)).excessRisk_le_two_mul_uniformDeviation
+          (μ := μ) (Z := Z) (hstar := hstar)
+          (bddAbove_range_riskDeviation
+            hn (fun h ↦ (hℓ_meas h).comp hZ) hℓ_bound (Z ∘ S))
+      linarith
+    _ ≤ δ := by
+      simpa [sampleConfidenceRadius, confidenceRadius] using
+        uniform_deviation_tail_bound_separable_of_sample_empirical_le_delta
+          (μ := μ) hn ℓ hℓ_meas Z hZ C hb hℓ_bound hℓ_cont hC hδ hδ_one
+
+/--
+Exact-ERM specialization of the expected-complexity tail bound.
+-/
+theorem erm_excessRisk_tail_bound_separable_of_rademacher_le
+    [MeasurableSpace 𝒵] [Nonempty 𝒵] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (ℓ : H → 𝒵 → ℝ) (hℓ_meas : ∀ h, Measurable (ℓ h))
+    (Z : Ω → 𝒵) (hZ : Measurable Z)
+    {b C : ℝ} (hb : 0 < b) (hℓ_bound : ∀ h z, |ℓ h z| ≤ b)
+    (hℓ_cont : ∀ z : 𝒵, Continuous fun h ↦ ℓ h z)
+    (A : (Fin n → 𝒵) → H)
+    (hA : ∀ S, IsERM n ℓ S (A S))
+    (hC : rademacherComplexity n ℓ μ Z ≤ C)
+    (hstar : H) {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S : Fin n → Ω |
+      4 * C + 2 * ε ≤ excessRisk ℓ μ Z (A (Z ∘ S)) hstar}).toReal ≤
+      (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  simpa using
+    approxERM_excessRisk_tail_bound_separable_of_rademacher_le
+      (μ := μ) hn ℓ hℓ_meas Z hZ hb hℓ_bound hℓ_cont A
+      (fun S ↦ (hA S).isApproxERM) hC hstar hε
+
+/--
+Apply the observed empirical-complexity theorem directly to the supervised
+loss class `(x,y) ↦ loss (F h x) y`.
+-/
+theorem supervised_approxERM_excessRisk_tail_bound_of_empirical_complexity
+    {𝒳 𝒴 : Type*}
+    [MeasurableSpace (𝒳 × 𝒴)] [Nonempty (𝒳 × 𝒴)] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (F : H → 𝒳 → ℝ) (loss : ℝ → 𝒴 → ℝ)
+    (hclass_meas : ∀ h, Measurable (supervisedLossClass F loss h))
+    (Z : Ω → 𝒳 × 𝒴) (hZ : Measurable Z)
+    {b η : ℝ}
+    (hb : 0 < b)
+    (hclass_bound : ∀ h z, |supervisedLossClass F loss h z| ≤ b)
+    (hclass_cont :
+      ∀ z : 𝒳 × 𝒴, Continuous fun h ↦ supervisedLossClass F loss h z)
+    (A : (Fin n → 𝒳 × 𝒴) → H)
+    (hA :
+      ∀ S, IsApproxERM η n (supervisedLossClass F loss) S (A S))
+    (hstar : H) {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S : Fin n → Ω |
+      4 * empiricalRademacherComplexity n
+            (supervisedLossClass F loss) (Z ∘ S) +
+          6 * ε + η ≤
+        excessRisk (supervisedLossClass F loss) μ Z
+          (A (Z ∘ S)) hstar}).toReal ≤
+      2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp :=
+  approxERM_excessRisk_tail_bound_separable_of_empirical_complexity
+    (μ := μ) hn (supervisedLossClass F loss) hclass_meas Z hZ
+    hb hclass_bound hclass_cont A hA hstar hε
+
+end

--- a/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/KernelPredictor.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/KernelPredictor.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import StatsMLlib.LearningTheory.EmpiricalRiskMinimization.Generalization
+import StatsMLlib.LearningTheory.Rademacher.Contraction
+import StatsMLlib.LearningTheory.FunctionClass.KernelPredictor
+import StatsMLlib.LearningTheory.Rademacher.Reindex
+
+/-!
+# Finite RKHS model selection with a Lipschitz loss
+
+The contraction theorem currently proved in this repository treats finite
+hypothesis types.  This module combines it with the feature-map RKHS trace
+estimate and the approximate-ERM oracle inequality.  Thus it provides a fully
+proved loss-to-excess-risk endpoint while leaving the extension of contraction
+to an arbitrary separable Hilbert ball as a separate task.
+-/
+
+noncomputable section
+
+universe u v w x y
+
+open MeasureTheory ProbabilityTheory Real TopologicalSpace
+open scoped ENNReal
+
+variable {n : ℕ}
+variable {Ω : Type u} [MeasurableSpace Ω]
+variable {𝒳 : Type v} {𝒴 : Type w}
+variable {E : Type x} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [CompleteSpace E]
+variable {G : Type y} [Fintype G] [Nonempty G]
+  [TopologicalSpace G] [DiscreteTopology G]
+variable {μ : Measure Ω}
+
+local notation "μⁿ" => Measure.pi (fun _ ↦ μ)
+
+/--
+Sample-dependent excess-risk bound for an approximate ERM over a finite
+collection of RKHS weights.
+
+The loss must vanish at prediction zero and be `L`-Lipschitz.  The resulting
+threshold contains
+
+`4 * (2 L Λ / n * sqrt(trace K_S))`,
+
+where the factor `2` is the contraction constant for this repository's
+absolute empirical Rademacher complexity.
+-/
+theorem finite_rkhs_approxERM_excessRisk_tail_bound_delta
+    [MeasurableSpace (𝒳 × 𝒴)] [Nonempty (𝒳 × 𝒴)]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (Φ : 𝒳 → E)
+    (Λ r : ℝ) (hΛ : 0 < Λ) (hr : 0 < r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (weights : G → Metric.closedBall (0 : E) Λ)
+    (loss : ℝ → 𝒴 → ℝ)
+    {L b η : ℝ} (hL : 0 ≤ L)
+    (hloss_zero : ∀ y, loss 0 y = 0)
+    (hloss_lip : ∀ y u v, |loss u y - loss v y| ≤ L * |u - v|)
+    (hclass_meas :
+      ∀ g, Measurable
+        (supervisedLossClass
+          (fun g x ↦ rkhsPredictor Φ (weights g) x) loss g))
+    (hb : 0 < b)
+    (hclass_bound :
+      ∀ g z,
+        |supervisedLossClass
+          (fun g x ↦ rkhsPredictor Φ (weights g) x) loss g z| ≤ b)
+    (Z : Ω → 𝒳 × 𝒴) (hZ : Measurable Z)
+    (A : (Fin n → 𝒳 × 𝒴) → G)
+    (hA : ∀ S,
+      IsApproxERM η n
+        (supervisedLossClass
+          (fun g x ↦ rkhsPredictor Φ (weights g) x) loss)
+        S (A S))
+    (gstar : G) {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      4 *
+          (2 * L *
+            (Λ * (n : ℝ)⁻¹ *
+              Real.sqrt
+                (kernelTrace Φ (fun k ↦ (Z (S k)).1)))) +
+          6 * sampleConfidenceRadius b δ n + η ≤
+        excessRisk
+          (supervisedLossClass
+            (fun g x ↦ rkhsPredictor Φ (weights g) x) loss)
+          μ Z (A (Z ∘ S)) gstar}).toReal ≤ δ := by
+  let predictor : G → 𝒳 → ℝ :=
+    fun g x ↦ rkhsPredictor Φ (weights g) x
+  let lossClass : G → (𝒳 × 𝒴) → ℝ :=
+    supervisedLossClass predictor loss
+  let C : (Fin n → 𝒳 × 𝒴) → ℝ :=
+    fun S ↦
+      2 * L *
+        (Λ * (n : ℝ)⁻¹ *
+          Real.sqrt (kernelTrace Φ (fun k ↦ (S k).1)))
+  have hC : ∀ S,
+      empiricalRademacherComplexity n lossClass S ≤ C S := by
+    intro S
+    have hcontract :
+        empiricalRademacherComplexity n lossClass S ≤
+          2 * L *
+            empiricalRademacherComplexity n
+              (fun (g : G) (z : 𝒳 × 𝒴) ↦ predictor g z.1) S := by
+      apply empiricalRademacherComplexity_contraction_finite
+        n (fun (g : G) (z : 𝒳 × 𝒴) ↦ predictor g z.1)
+          (fun z u ↦ loss u z.2) S hL
+      · exact fun z ↦ hloss_zero z.2
+      · exact fun z u v ↦ hloss_lip z.2 u v
+    have hsubclass :
+        empiricalRademacherComplexity n
+            (fun (g : G) (z : 𝒳 × 𝒴) ↦ predictor g z.1) S ≤
+          empiricalRademacherComplexity n
+            (fun (w : Metric.closedBall (0 : E) Λ) (z : 𝒳 × 𝒴) ↦
+              rkhsPredictor Φ w z.1) S := by
+      exact empiricalRademacherComplexity_reindex_le
+        (fun (w : Metric.closedBall (0 : E) Λ) (z : 𝒳 × 𝒴) ↦
+          rkhsPredictor Φ w z.1)
+        weights S
+        (mul_nonneg hr.le hΛ.le)
+        (fun w z ↦ abs_rkhsPredictor_le
+          Φ hΛ.le hr.le hdiag w z.1)
+    have htrace :
+        empiricalRademacherComplexity n
+            (fun (w : Metric.closedBall (0 : E) Λ) (z : 𝒳 × 𝒴) ↦
+              rkhsPredictor Φ w z.1) S ≤
+          Λ * (n : ℝ)⁻¹ *
+            Real.sqrt (kernelTrace Φ (fun k ↦ (S k).1)) := by
+      -- `rkhsPredictor (fun z ↦ Φ z.1)` and `fun w z ↦ rkhsPredictor Φ w z.1` are
+      -- definitionally equal, but `simp` cannot unfold the first: it occurs
+      -- unapplied. Restating through a typed `have` forces the check instead.
+      have h :
+          empiricalRademacherComplexity n
+              (fun (w : Metric.closedBall (0 : E) Λ) (z : 𝒳 × 𝒴) ↦
+                rkhsPredictor Φ w z.1) S ≤
+            Λ * (n : ℝ)⁻¹ *
+              Real.sqrt (∑ k, inner ℝ (Φ (S k).1) (Φ (S k).1)) :=
+        rkhs_empiricalRademacherComplexity_le_kernelTrace
+          (Φ := fun z : 𝒳 × 𝒴 ↦ Φ z.1) Λ hΛ.le S
+      simpa only [kernelTrace, kernelOfFeatureMap] using h
+    calc
+      empiricalRademacherComplexity n lossClass S ≤
+          2 * L *
+            empiricalRademacherComplexity n
+              (fun (g : G) (z : 𝒳 × 𝒴) ↦ predictor g z.1) S :=
+        hcontract
+      _ ≤ 2 * L *
+          (Λ * (n : ℝ)⁻¹ *
+            Real.sqrt (kernelTrace Φ (fun k ↦ (S k).1))) := by
+        gcongr
+        exact hsubclass.trans htrace
+      _ = C S := rfl
+  have htail :=
+    approxERM_excessRisk_tail_bound_separable_of_sample_empirical_le_delta
+      (μ := μ) hn lossClass
+      (by simpa only [lossClass, predictor] using hclass_meas)
+      Z hZ C hb
+      (by simpa only [lossClass, predictor] using hclass_bound)
+      (fun _ ↦ continuous_of_discreteTopology)
+      A
+      (by simpa only [lossClass, predictor] using hA)
+      hC gstar hδ hδ_one
+  simpa only [lossClass, predictor, C, Function.comp_apply] using htail
+
+end

--- a/StatsMLlib/LearningTheory/Rademacher/Contraction.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Contraction.lean
@@ -1,0 +1,518 @@
+/-
+Copyright (c) 2026 Kei Tsukamoto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sho Sonoda, Kei Tsukamoto
+-/
+import StatsMLlib.LearningTheory.EmpiricalRiskMinimization.Defs
+import StatsMLlib.LearningTheory.Rademacher.Signs
+
+/-!
+# A finite-class Rademacher contraction inequality
+
+For the absolute empirical Rademacher complexity used in this project, a
+Lipschitz map vanishing at zero costs a factor `2`.  The factor appears when
+the absolute supremum is split into its positive and negative one-sided
+parts.  For the one-sided convention the contraction lemma below has factor
+`1`.
+
+The implementation in this file treats finite hypothesis types.  This is
+already useful for finite model selection and, unlike an assumption packaged
+as a predicate, records a fully proved contraction principle.  Extensions to
+general separable classes can be built by dense finite approximation.
+-/
+
+noncomputable section
+
+universe u v
+
+open Real
+open scoped BigOperators
+
+variable {H : Type u} {𝒳 : Type v}
+
+private lemma two_iSup_contraction
+    [Fintype H] [Nonempty H]
+    (A x : H → ℝ) (ψ : ℝ → ℝ) {L : ℝ}
+    (hψ : ∀ u v, |ψ u - ψ v| ≤ L * |u - v|) :
+    (⨆ h, A h + ψ (x h)) + (⨆ h, A h - ψ (x h)) ≤
+      (⨆ h, A h + L * x h) + (⨆ h, A h - L * x h) := by
+  obtain ⟨h₁, hh₁⟩ :=
+    exists_eq_ciSup_of_finite (f := fun h ↦ A h + ψ (x h))
+  obtain ⟨h₂, hh₂⟩ :=
+    exists_eq_ciSup_of_finite (f := fun h ↦ A h - ψ (x h))
+  rw [← hh₁, ← hh₂]
+  by_cases hx : x h₂ ≤ x h₁
+  · have hdiff : ψ (x h₁) - ψ (x h₂) ≤ L * (x h₁ - x h₂) := by
+      calc
+        ψ (x h₁) - ψ (x h₂) ≤ |ψ (x h₁) - ψ (x h₂)| :=
+          le_abs_self _
+        _ ≤ L * |x h₁ - x h₂| := hψ _ _
+        _ = L * (x h₁ - x h₂) := by rw [abs_of_nonneg (sub_nonneg.mpr hx)]
+    calc
+      (A h₁ + ψ (x h₁)) + (A h₂ - ψ (x h₂)) =
+          A h₁ + A h₂ + (ψ (x h₁) - ψ (x h₂)) := by ring
+      _ ≤ A h₁ + A h₂ + L * (x h₁ - x h₂) := by linarith
+      _ = (A h₁ + L * x h₁) + (A h₂ - L * x h₂) := by ring
+      _ ≤ (⨆ h, A h + L * x h) + (⨆ h, A h - L * x h) := by
+        exact add_le_add
+          (le_ciSup
+            (f := fun h ↦ A h + L * x h) (Finite.bddAbove_range _) h₁)
+          (le_ciSup
+            (f := fun h ↦ A h - L * x h) (Finite.bddAbove_range _) h₂)
+  · have hx' : x h₁ ≤ x h₂ := le_of_not_ge hx
+    have hdiff : ψ (x h₁) - ψ (x h₂) ≤ L * (x h₂ - x h₁) := by
+      calc
+        ψ (x h₁) - ψ (x h₂) ≤ |ψ (x h₁) - ψ (x h₂)| :=
+          le_abs_self _
+        _ ≤ L * |x h₁ - x h₂| := hψ _ _
+        _ = L * (x h₂ - x h₁) := by rw [abs_sub_comm, abs_of_nonneg (sub_nonneg.mpr hx')]
+    calc
+      (A h₁ + ψ (x h₁)) + (A h₂ - ψ (x h₂)) =
+          A h₁ + A h₂ + (ψ (x h₁) - ψ (x h₂)) := by ring
+      _ ≤ A h₁ + A h₂ + L * (x h₂ - x h₁) := by linarith
+      _ = (A h₂ + L * x h₂) + (A h₁ - L * x h₁) := by ring
+      _ ≤ (⨆ h, A h + L * x h) + (⨆ h, A h - L * x h) := by
+        exact add_le_add
+          (le_ciSup
+            (f := fun h ↦ A h + L * x h) (Finite.bddAbove_range _) h₂)
+          (le_ciSup
+            (f := fun h ↦ A h - L * x h) (Finite.bddAbove_range _) h₁)
+
+/--
+The finite-sign, one-sided contraction principle, strengthened by an arbitrary
+offset `c`.  The offset is what makes induction over the sample coordinates
+possible.
+-/
+private theorem sum_iSup_contraction_one_sided
+    [Fintype H] [Nonempty H]
+    (n : ℕ) (a : H → Fin n → ℝ) (ψ : Fin n → ℝ → ℝ)
+    (c : H → ℝ) {L : ℝ}
+    (hψ : ∀ k u v, |ψ k u - ψ k v| ≤ L * |u - v|) :
+    (∑ σ : Signs n,
+        ⨆ h, c h + ∑ k : Fin n, (σ k : ℝ) * ψ k (a h k)) ≤
+      ∑ σ : Signs n,
+        ⨆ h, c h + L * ∑ k : Fin n, (σ k : ℝ) * a h k := by
+  induction n generalizing c with
+  | zero =>
+      simp
+  | succ m ih =>
+      let a₀ : H → Fin m → ℝ := fun h k ↦ a h k.castSucc
+      let ψ₀ : Fin m → ℝ → ℝ := fun k ↦ ψ k.castSucc
+      let x : H → ℝ := fun h ↦ a h (Fin.last m)
+      have hψ₀ : ∀ k u v, |ψ₀ k u - ψ₀ k v| ≤ L * |u - v| :=
+        fun k u v ↦ hψ k.castSucc u v
+      have hlast :
+          ∑ τ : Signs m,
+              ((⨆ h,
+                  c h + (∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) +
+                    ψ (Fin.last m) (x h)) +
+                (⨆ h,
+                  c h + (∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) -
+                    ψ (Fin.last m) (x h))) ≤
+            ∑ τ : Signs m,
+              ((⨆ h,
+                  c h + (∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) +
+                    L * x h) +
+                (⨆ h,
+                  c h + (∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) -
+                    L * x h)) := by
+        apply Finset.sum_le_sum
+        intro τ _
+        let A : H → ℝ :=
+          fun h ↦ c h + ∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)
+        simpa [A, add_assoc] using
+          two_iSup_contraction A x (ψ (Fin.last m))
+            (hψ (Fin.last m))
+      have hminus :=
+        ih (a := a₀) (ψ := ψ₀) (c := fun h ↦ c h - L * x h) hψ₀
+      have hplus :=
+        ih (a := a₀) (ψ := ψ₀) (c := fun h ↦ c h + L * x h) hψ₀
+      let q : ℤ → Signs m → ℝ :=
+        fun s τ ↦
+          ⨆ h,
+            c h +
+              ((∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) +
+                (s : ℝ) * ψ (Fin.last m) (x h))
+      let qL : ℤ → Signs m → ℝ :=
+        fun s τ ↦
+          ⨆ h,
+            c h +
+              L *
+                ((∑ k : Fin m, (τ k : ℝ) * a₀ h k) +
+                  (s : ℝ) * x h)
+      calc
+        (∑ σ : Signs (m + 1),
+            ⨆ h, c h + ∑ k : Fin (m + 1),
+              (σ k : ℝ) * ψ k (a h k)) =
+          ∑ σ : Signs (m + 1), q (σ (Fin.last m)) (Fin.init σ) := by
+              apply Finset.sum_congr rfl
+              intro σ _
+              dsimp only [q]
+              apply congrArg
+              funext h
+              rw [Fin.sum_univ_castSucc]
+              rfl
+        _ =
+          ∑ s ∈ ({-1, 1} : Finset ℤ), ∑ τ : Signs m,
+              ⨆ h,
+                c h +
+                  ((∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) +
+                    (s : ℝ) * ψ (Fin.last m) (x h)) := by
+              exact (sigma_eq (n := m) q).symm
+        _ =
+            ∑ τ : Signs m,
+              ((⨆ h,
+                  c h + (∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) -
+                    ψ (Fin.last m) (x h)) +
+                (⨆ h,
+                  c h + (∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) +
+                    ψ (Fin.last m) (x h))) := by
+              simp [Finset.sum_add_distrib, add_comm, add_left_comm]
+              apply Finset.sum_congr rfl
+              intro τ _
+              apply congrArg
+              funext h
+              ring
+        _ ≤ ∑ τ : Signs m,
+              ((⨆ h,
+                  c h + (∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) -
+                    L * x h) +
+                (⨆ h,
+                  c h + (∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) +
+                    L * x h)) := by
+              simpa [add_comm] using hlast
+        _ = (∑ τ : Signs m,
+              ⨆ h,
+                (c h - L * x h) +
+                  ∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k)) +
+            ∑ τ : Signs m,
+              ⨆ h,
+                (c h + L * x h) +
+                  ∑ k : Fin m, (τ k : ℝ) * ψ₀ k (a₀ h k) := by
+              simp only [Finset.sum_add_distrib]
+              congr 1 <;> apply Finset.sum_congr rfl <;> intro τ _ <;>
+                apply congrArg <;> funext h <;> ring
+        _ ≤ (∑ τ : Signs m,
+              ⨆ h,
+                (c h - L * x h) +
+                  L * ∑ k : Fin m, (τ k : ℝ) * a₀ h k) +
+            ∑ τ : Signs m,
+              ⨆ h,
+                (c h + L * x h) +
+                  L * ∑ k : Fin m, (τ k : ℝ) * a₀ h k :=
+              add_le_add hminus hplus
+        _ = ∑ s ∈ ({-1, 1} : Finset ℤ), ∑ τ : Signs m,
+              ⨆ h,
+                c h +
+                  L *
+                    ((∑ k : Fin m, (τ k : ℝ) * a₀ h k) +
+                      (s : ℝ) * x h) := by
+              simp [add_comm, add_assoc]
+              congr 1 <;> apply Finset.sum_congr rfl <;> intro τ _ <;>
+                apply congrArg <;> funext h <;> ring
+        _ = ∑ σ : Signs (m + 1), qL (σ (Fin.last m)) (Fin.init σ) :=
+              sigma_eq (n := m) qL
+        _ = ∑ σ : Signs (m + 1),
+              ⨆ h, c h + L * ∑ k : Fin (m + 1),
+                (σ k : ℝ) * a h k := by
+              apply Finset.sum_congr rfl
+              intro σ _
+              dsimp only [qL]
+              apply congrArg
+              funext h
+              rw [Fin.sum_univ_castSucc]
+              rfl
+
+/--
+One-sided empirical Rademacher contraction for a finite hypothesis class.
+
+Unlike the absolute convention, the one-sided convention has constant `L`.
+The map may depend on the observation `x`; this is useful for supervised
+losses, where the contraction map depends on the observed label.
+-/
+theorem empiricalRademacherComplexity_without_abs_contraction_finite
+    [Fintype H] [Nonempty H]
+    (n : ℕ) (F : H → 𝒳 → ℝ) (ψ : 𝒳 → ℝ → ℝ)
+    (S : Fin n → 𝒳) {L : ℝ} (hL : 0 ≤ L)
+    (hψ : ∀ x u v, |ψ x u - ψ x v| ≤ L * |u - v|) :
+    empiricalRademacherComplexity_without_abs n
+        (fun h x ↦ ψ x (F h x)) S ≤
+      L * empiricalRademacherComplexity_without_abs n F S := by
+  let q : ℝ := (n : ℝ)⁻¹
+  have hq : 0 ≤ q := by positivity
+  have hcontract :=
+    sum_iSup_contraction_one_sided n
+      (fun h k ↦ F h (S k))
+      (fun k u ↦ q * ψ (S k) u)
+      (fun _ ↦ 0) (by
+        intro k u v
+        rw [← mul_sub, abs_mul, abs_of_nonneg hq]
+        calc
+          q * |ψ (S k) u - ψ (S k) v| ≤
+              q * (L * |u - v|) := by
+            gcongr
+            exact hψ (S k) u v
+          _ = (q * L) * |u - v| := by ring)
+  dsimp only [empiricalRademacherComplexity_without_abs]
+  calc
+    (Fintype.card (Signs n) : ℝ)⁻¹ *
+        (∑ σ : Signs n,
+        ⨆ h, (n : ℝ)⁻¹ *
+          ∑ k : Fin n, (σ k : ℝ) * ψ (S k) (F h (S k))) =
+      (Fintype.card (Signs n) : ℝ)⁻¹ *
+        (∑ σ : Signs n,
+          ⨆ h, (0 : ℝ) +
+            ∑ k : Fin n, (σ k : ℝ) *
+              (q * ψ (S k) (F h (S k)))) := by
+        congr 1
+        apply Finset.sum_congr rfl
+        intro σ _
+        apply congrArg
+        funext h
+        simp only [zero_add, q]
+        rw [Finset.mul_sum]
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+    _ ≤ (Fintype.card (Signs n) : ℝ)⁻¹ *
+        (∑ σ : Signs n,
+          ⨆ h, (0 : ℝ) + (q * L) *
+            ∑ k : Fin n, (σ k : ℝ) * F h (S k)) :=
+      mul_le_mul_of_nonneg_left hcontract (by positivity)
+    _ = (Fintype.card (Signs n) : ℝ)⁻¹ *
+        (L * ∑ σ : Signs n,
+          ⨆ h, (n : ℝ)⁻¹ *
+            ∑ k : Fin n, (σ k : ℝ) * F h (S k)) := by
+      congr 1
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro σ _
+      obtain ⟨hmax, hhmax⟩ :=
+        exists_eq_ciSup_of_finite
+          (f := fun h ↦ (n : ℝ)⁻¹ *
+            ∑ k : Fin n, (σ k : ℝ) * F h (S k))
+      apply le_antisymm
+      · apply ciSup_le
+        intro h
+        calc
+          0 + (q * L) * ∑ k : Fin n, (σ k : ℝ) * F h (S k) =
+              L * ((n : ℝ)⁻¹ *
+                ∑ k : Fin n, (σ k : ℝ) * F h (S k)) := by
+            simp only [zero_add, q]
+            ring
+          _ ≤ L * (⨆ h, (n : ℝ)⁻¹ *
+                ∑ k : Fin n, (σ k : ℝ) * F h (S k)) := by
+            gcongr
+            exact le_ciSup
+              (f := fun h ↦ (n : ℝ)⁻¹ *
+                ∑ k : Fin n, (σ k : ℝ) * F h (S k))
+              (Finite.bddAbove_range _) h
+      · rw [← hhmax]
+        calc
+          L * ((n : ℝ)⁻¹ *
+              ∑ k : Fin n, (σ k : ℝ) * F hmax (S k)) =
+              0 + (q * L) *
+                ∑ k : Fin n, (σ k : ℝ) * F hmax (S k) := by
+            simp only [zero_add, q]
+            ring
+          _ ≤ ⨆ h, 0 + (q * L) *
+              ∑ k : Fin n, (σ k : ℝ) * F h (S k) :=
+            le_ciSup
+              (f := fun h ↦ 0 + (q * L) *
+                ∑ k : Fin n, (σ k : ℝ) * F h (S k))
+              (Finite.bddAbove_range _) hmax
+    _ = L * ((Fintype.card (Signs n) : ℝ)⁻¹ *
+        ∑ σ : Signs n,
+          ⨆ h, (n : ℝ)⁻¹ *
+            ∑ k : Fin n, (σ k : ℝ) * F h (S k)) := by ring
+
+/-- Add a zero function to a function class. -/
+def withZeroClass (F : H → 𝒳 → ℝ) : Option H → 𝒳 → ℝ
+  | none, _ => 0
+  | some h, x => F h x
+
+private lemma empiricalRademacherComplexity_le_pos_add_neg
+    [Fintype H] [Nonempty H]
+    (n : ℕ) (G : H → 𝒳 → ℝ) (S : Fin n → 𝒳) :
+    empiricalRademacherComplexity n G S ≤
+      empiricalRademacherComplexity_without_abs n (withZeroClass G) S +
+      empiricalRademacherComplexity_without_abs n
+        (fun oh x ↦ -withZeroClass G oh x) S := by
+  dsimp only [empiricalRademacherComplexity,
+    empiricalRademacherComplexity_without_abs]
+  rw [← mul_add, ← Finset.sum_add_distrib]
+  apply mul_le_mul_of_nonneg_left _ (by positivity)
+  apply Finset.sum_le_sum
+  intro σ _
+  let A : H → ℝ :=
+    fun h ↦ (n : ℝ)⁻¹ *
+      ∑ k : Fin n, (σ k : ℝ) * G h (S k)
+  let B : Option H → ℝ
+    | none => 0
+    | some h => A h
+  have hneg :
+      (fun oh : Option H ↦
+        (n : ℝ)⁻¹ * ∑ k : Fin n,
+          (σ k : ℝ) * -withZeroClass G oh (S k)) = fun oh ↦ -B oh := by
+    funext oh
+    cases oh <;> simp [B, A, withZeroClass, Finset.sum_neg_distrib]
+  have hpos :
+      (fun oh : Option H ↦
+        (n : ℝ)⁻¹ * ∑ k : Fin n,
+          (σ k : ℝ) * withZeroClass G oh (S k)) = B := by
+    funext oh
+    cases oh <;> simp [B, A, withZeroClass]
+  rw [hpos, hneg]
+  apply ciSup_le
+  intro h
+  rw [abs_eq_max_neg]
+  apply max_le
+  · calc
+      A h ≤ ⨆ oh, B oh :=
+        le_ciSup (f := B) (Finite.bddAbove_range _) (some h)
+      _ ≤ (⨆ oh, B oh) + ⨆ oh, -B oh := by
+        have hz : 0 ≤ ⨆ oh, -B oh := by
+          have : (0 : ℝ) = -B none := by simp [B]
+          rw [this]
+          exact le_ciSup (f := fun oh ↦ -B oh)
+            (Finite.bddAbove_range _) none
+        linarith
+  · calc
+      -A h ≤ ⨆ oh, -B oh :=
+        le_ciSup (f := fun oh ↦ -B oh)
+          (Finite.bddAbove_range _) (some h)
+      _ ≤ (⨆ oh, B oh) + ⨆ oh, -B oh := by
+        have hz : 0 ≤ ⨆ oh, B oh := by
+          have : (0 : ℝ) = B none := by simp [B]
+          rw [this]
+          exact le_ciSup (f := B) (Finite.bddAbove_range _) none
+        linarith
+
+private lemma empiricalRademacherComplexity_without_abs_withZero_le
+    [Fintype H] [Nonempty H]
+    (n : ℕ) (F : H → 𝒳 → ℝ) (S : Fin n → 𝒳) :
+    empiricalRademacherComplexity_without_abs n (withZeroClass F) S ≤
+      empiricalRademacherComplexity n F S := by
+  dsimp only [empiricalRademacherComplexity_without_abs,
+    empiricalRademacherComplexity]
+  apply mul_le_mul_of_nonneg_left _ (by positivity)
+  apply Finset.sum_le_sum
+  intro σ _
+  apply ciSup_le
+  intro oh
+  cases oh with
+  | none =>
+      simp only [withZeroClass, mul_zero, Finset.sum_const_zero, mul_zero]
+      exact Real.iSup_nonneg fun h ↦
+        abs_nonneg ((n : ℝ)⁻¹ *
+          ∑ k : Fin n, (σ k : ℝ) * F h (S k))
+  | some h =>
+      calc
+        (n : ℝ)⁻¹ *
+            ∑ k : Fin n, (σ k : ℝ) * withZeroClass F (some h) (S k) =
+            (n : ℝ)⁻¹ * ∑ k : Fin n, (σ k : ℝ) * F h (S k) := by
+          rfl
+        _ ≤ |(n : ℝ)⁻¹ *
+            ∑ k : Fin n, (σ k : ℝ) * F h (S k)| :=
+          le_abs_self _
+        _ ≤ ⨆ h, |(n : ℝ)⁻¹ *
+            ∑ k : Fin n, (σ k : ℝ) * F h (S k)| :=
+          le_ciSup
+            (f := fun h ↦ |(n : ℝ)⁻¹ *
+              ∑ k : Fin n, (σ k : ℝ) * F h (S k)|)
+            (Finite.bddAbove_range _) h
+
+/--
+Absolute empirical Rademacher contraction for a finite hypothesis class.
+
+Because `empiricalRademacherComplexity` takes an absolute value inside the
+hypothesis supremum, the general Lipschitz contraction constant is `2 * L`.
+For the one-sided definition, use
+`empiricalRademacherComplexity_without_abs_contraction_finite`, whose constant
+is `L`.
+-/
+theorem empiricalRademacherComplexity_contraction_finite
+    [Fintype H] [Nonempty H]
+    (n : ℕ) (F : H → 𝒳 → ℝ) (ψ : 𝒳 → ℝ → ℝ)
+    (S : Fin n → 𝒳) {L : ℝ} (hL : 0 ≤ L)
+    (hψ_zero : ∀ x, ψ x 0 = 0)
+    (hψ : ∀ x u v, |ψ x u - ψ x v| ≤ L * |u - v|) :
+    empiricalRademacherComplexity n
+        (fun h x ↦ ψ x (F h x)) S ≤
+      2 * L * empiricalRademacherComplexity n F S := by
+  let G : H → 𝒳 → ℝ := fun h x ↦ ψ x (F h x)
+  have hsplit :=
+    empiricalRademacherComplexity_le_pos_add_neg n G S
+  have hpos :
+      empiricalRademacherComplexity_without_abs n (withZeroClass G) S ≤
+        L * empiricalRademacherComplexity_without_abs n
+          (withZeroClass F) S := by
+    have hclass :
+        (fun oh x ↦ ψ x (withZeroClass F oh x)) = withZeroClass G := by
+      funext oh x
+      cases oh <;> simp [withZeroClass, G, hψ_zero]
+    rw [← hclass]
+    exact empiricalRademacherComplexity_without_abs_contraction_finite
+      n (withZeroClass F) ψ S hL hψ
+  have hneg :
+      empiricalRademacherComplexity_without_abs n
+          (fun oh x ↦ -withZeroClass G oh x) S ≤
+        L * empiricalRademacherComplexity_without_abs n
+          (withZeroClass F) S := by
+    let ψneg : 𝒳 → ℝ → ℝ := fun x u ↦ -ψ x u
+    have hψneg : ∀ x u v, |ψneg x u - ψneg x v| ≤ L * |u - v| := by
+      intro x u v
+      change |-ψ x u - -ψ x v| ≤ L * |u - v|
+      rw [show -ψ x u - -ψ x v = -(ψ x u - ψ x v) by ring, abs_neg]
+      exact hψ x u v
+    have hclass :
+        (fun oh x ↦ ψneg x (withZeroClass F oh x)) =
+          fun oh x ↦ -withZeroClass G oh x := by
+      funext oh x
+      cases oh <;> simp [withZeroClass, G, ψneg, hψ_zero]
+    rw [← hclass]
+    exact empiricalRademacherComplexity_without_abs_contraction_finite
+      n (withZeroClass F) ψneg S hL hψneg
+  have hraw :=
+    empiricalRademacherComplexity_without_abs_withZero_le n F S
+  calc
+    empiricalRademacherComplexity n G S ≤
+        empiricalRademacherComplexity_without_abs n (withZeroClass G) S +
+          empiricalRademacherComplexity_without_abs n
+            (fun oh x ↦ -withZeroClass G oh x) S :=
+      hsplit
+    _ ≤ L * empiricalRademacherComplexity_without_abs n
+          (withZeroClass F) S +
+        L * empiricalRademacherComplexity_without_abs n
+          (withZeroClass F) S :=
+      add_le_add hpos hneg
+    _ ≤ L * empiricalRademacherComplexity n F S +
+        L * empiricalRademacherComplexity n F S := by
+      gcongr
+    _ = 2 * L * empiricalRademacherComplexity n F S := by ring
+
+/--
+Contraction for a centered supervised loss class over a finite hypothesis
+type.  The loss is centered by subtracting `loss 0 y`, so the contraction map
+vanishes at zero.
+-/
+theorem empiricalRademacherComplexity_centered_supervisedLossClass_le
+    {𝒴 : Type*}
+    [Fintype H] [Nonempty H]
+    (n : ℕ) (F : H → 𝒳 → ℝ) (loss : ℝ → 𝒴 → ℝ)
+    (S : Fin n → 𝒳 × 𝒴) {L : ℝ} (hL : 0 ≤ L)
+    (hloss : ∀ y u v, |loss u y - loss v y| ≤ L * |u - v|) :
+    empiricalRademacherComplexity n
+        (supervisedLossClass F (centeredLoss loss)) S ≤
+      2 * L *
+        empiricalRademacherComplexity n
+          (fun (h : H) (z : 𝒳 × 𝒴) ↦ F h z.1) S := by
+  apply empiricalRademacherComplexity_contraction_finite
+    n (fun (h : H) (z : 𝒳 × 𝒴) ↦ F h z.1)
+      (fun z u ↦ centeredLoss loss u z.2) S hL
+  · intro z
+    exact centeredLoss_zero loss z.2
+  · intro z u v
+    simpa [centeredLoss, sub_sub_sub_cancel_right] using hloss z.2 u v
+
+end


### PR DESCRIPTION
**No design decision in this PR.** Straight port; the single departure from upstream text
is described below.

Fifteen declarations from `auto-res/lean-rademacher` at **`bc33376`** in three new
modules, covering appendix C-3's PRs **15 and 16**. 956 added lines, over C-1's 600-line
目安, stated here as C-1 asks — `Learning/Contraction.lean` alone is 513 lines upstream
and cannot be split without cutting a proof.

## What is added

**`Rademacher/Contraction.lean`** (new, 8 declarations) — Talagrand's contraction
principle: composing a function class with Lipschitz maps multiplies its empirical
Rademacher complexity by at most the Lipschitz constant. The largest single upstream file
in this port.

**`EmpiricalRiskMinimization/Generalization.lean`** (new, 6) — the deterministic oracle
inequality of #27 turned into high-probability excess-risk bounds.

**`EmpiricalRiskMinimization/KernelPredictor.lean`** (new, 1) — the same for a
feature-map kernel class, where contraction converts the loss-class complexity into the
predictor-class complexity, closing the chain that started with `HilbertPredictor` in #21.

## Provenance against `bc33376`

`upstream-only = 0` on all three. **Fourteen of the fifteen are byte-identical to
upstream**, including the whole of `Contraction.lean` — 513 lines of the heaviest proof in
the port, needing no v4.33 repair at all.

The exception is one step in `KernelPredictor.lean`:

```diff
-      simpa [rkhsPredictor, Function.comp_def, kernelTrace,
-        kernelOfFeatureMap] using
-        (rkhs_empiricalRademacherComplexity_le_kernelTrace
-          (Φ := fun z : 𝒳 × 𝒴 ↦ Φ z.1) Λ hΛ.le S)
+      have h : empiricalRademacherComplexity n
+            (fun (w : Metric.closedBall (0 : E) Λ) (z : 𝒳 × 𝒴) ↦
+              rkhsPredictor Φ w z.1) S ≤ … :=
+        rkhs_empiricalRademacherComplexity_le_kernelTrace
+          (Φ := fun z : 𝒳 × 𝒴 ↦ Φ z.1) Λ hΛ.le S
+      simpa only [kernelTrace, kernelOfFeatureMap] using h
```

The term proves the bound for `rkhsPredictor (fun z ↦ Φ z.1)`; the goal states it for
`fun w z ↦ rkhsPredictor Φ w z.1`. Both unfold to `hilbertPredictor w (Φ z.1)`, so they
are definitionally equal — but `simp` cannot bridge them in either direction: adding
`rkhsPredictor` unfolds the goal and leaves the term, since there the occurrence is
*unapplied*, and omitting it leaves both folded but syntactically different. A typed
`have` forces the definitional check that `simp` will not do.

This is the fourth appearance of the same shape (#11, #21, #23), and by now the reliable
move is to stop reaching for `simp` and state the intermediate type.

## Verification

- `lake build` green across all 8811 jobs, changed files touched first so they really
  rebuild, and **no warnings** in the build output.
- All three new modules type-check from a standalone `import`.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- `FILE_TREE.md` cross-checked against the real tree: 105 modules, `LearningTheory` 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
