### PR TITLE
Add the acceptance examples and the generalization-bound API table

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ Representative declarations include `dudley`, `truncated_dudley_entropy_bound`, 
 `RMT.matrix_bernstein_inequality_hdp_all`, `expectation_le_rademacher`, and
 `master_error_bound`.
 
+## Generalization bounds
+
+The Rademacher-complexity route from a fixed-sample bound to a high-probability
+generalization bound. Each entry names the endpoint; every module listed carries acceptance
+`example`s of the same statements under an `## Examples` heading.
+
+| Model | Module | Endpoint |
+| --- | --- | --- |
+| any countable class | `LearningTheory/UniformDeviation/Confidence` | `uniform_deviation_tail_bound_countable_of_empirical_le_delta` |
+| any separable class | `LearningTheory/UniformDeviation/Confidence` | `uniform_deviation_tail_bound_separable_of_empirical_le_delta` |
+| `ℓ₂` linear predictors | `LearningTheory/FunctionClass/LinearPredictor/L2` | `linear_predictor_l2_uniform_deviation_tail_bound_delta` |
+| `ℓ₁/ℓ∞` linear predictors | `LearningTheory/FunctionClass/LinearPredictor/L1` | `linear_predictor_l1_uniform_deviation_tail_bound_delta` |
+| feature-map RKHS predictors | `LearningTheory/FunctionClass/KernelPredictor` | `rkhs_uniformDeviation_tail_bound_kernelTrace_delta` |
+| via Dudley's entropy integral | `LearningTheory/Rademacher/Dudley` | `uniform_deviation_tail_bound_separable_of_dudley_delta` |
+| finite hypothesis classes | `LearningTheory/Rademacher/FiniteClass` | `uniform_deviation_tail_bound_finite_of_dudley_quarter_delta` |
+| Lipschitz-parametrized families | `LearningTheory/Rademacher/LipschitzParameter` | `uniform_deviation_tail_bound_lipschitzParameter_dudley_delta` |
+| approximate ERM, excess risk | `LearningTheory/EmpiricalRiskMinimization/Generalization` | `approxERM_excessRisk_tail_bound_separable_of_sample_empirical_le_delta` |
+| the same over an RKHS ball | `LearningTheory/EmpiricalRiskMinimization/KernelPredictor` | `finite_rkhs_approxERM_excessRisk_tail_bound_delta` |
+
+Supporting notions: `empiricalRademacherComplexity` and `rademacherComplexity`
+(`LearningTheory/Rademacher/Defs`), `uniformDeviation`
+(`LearningTheory/UniformDeviation/Defs`), `coveringNumber`
+(`Topology/MetricSpace/CoveringNumber/Basic`), `IsERM` and `excessRisk`
+(`LearningTheory/EmpiricalRiskMinimization/Defs`).
+
 ## Getting started
 
 StatsMLlib is pinned to Lean and Mathlib `v4.33.0`.

--- a/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Generalization.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Generalization.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sho Sonoda, Kei Tsukamoto
 -/
 import StatsMLlib.LearningTheory.EmpiricalRiskMinimization.Basic
+import StatsMLlib.LearningTheory.Rademacher.Contraction
 import StatsMLlib.LearningTheory.UniformDeviation.Confidence
 
 /-!
@@ -266,5 +267,90 @@ theorem supervised_approxERM_excessRisk_tail_bound_of_empirical_complexity
   approxERM_excessRisk_tail_bound_separable_of_empirical_complexity
     (μ := μ) hn (supervisedLossClass F loss) hclass_meas Z hZ
     hb hclass_bound hclass_cont A hA hstar hε
+
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+## Approximate ERM and excess risk
+
+Let `A(S)` be an $\eta$-approximate empirical risk minimizer for a bounded
+loss class $\ell$.  The deterministic oracle inequality
+
+$$
+R(A(S))-R(h^\star)
+\leq
+2\operatorname{UD}_n(\ell;S)+\eta
+$$
+
+composes with the observed empirical Rademacher estimate to give
+
+$$
+\Pr\!\left\{
+R(A(S))-R(h^\star)
+\geq
+4C(S)+6b\sqrt{\frac{2\log(2/\delta)}{n}}+\eta
+\right\}
+\leq\delta,
+$$
+
+whenever
+$\widehat{\mathfrak R}_n(\ell;S)\leq C(S)$.
+The learning rule itself need not be measurable: the conclusion uses outer
+probability through `Measure.real`.
+-/
+
+/-- Main sample-dependent excess-risk example for an approximate ERM. -/
+example
+    [MeasurableSpace 𝒵] [Nonempty 𝒵] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (ℓ : H → 𝒵 → ℝ) (hℓ_meas : ∀ h, Measurable (ℓ h))
+    (X : Ω → 𝒵) (hX : Measurable X)
+    (C : (Fin n → 𝒵) → ℝ)
+    {b η δ : ℝ} (hb : 0 < b) (hℓ_bound : ∀ h x, |ℓ h x| ≤ b)
+    (hℓ_cont : ∀ x : 𝒵, Continuous fun h ↦ ℓ h x)
+    (A : (Fin n → 𝒵) → H)
+    (hA : ∀ S, IsApproxERM η n ℓ S (A S))
+    (hC : ∀ S, empiricalRademacherComplexity n ℓ S ≤ C S)
+    (hstar : H) (hn : 0 < n) (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      4 * C (X ∘ S) + 6 * sampleConfidenceRadius b δ n + η ≤
+        excessRisk ℓ μ X (A (X ∘ S)) hstar}).toReal ≤ δ := by
+  exact approxERM_excessRisk_tail_bound_separable_of_sample_empirical_le_delta
+    (μ := μ) hn ℓ hℓ_meas X hX C hb hℓ_bound hℓ_cont
+    A hA hC hstar hδ hδ_one
+
+/-!
+For a finite hypothesis type, a centered $L$-Lipschitz loss satisfies the
+absolute-complexity contraction estimate
+
+$$
+\widehat{\mathfrak R}_n((\ell-\ell(0,\cdot))\circ F;S)
+\leq
+2L\,\widehat{\mathfrak R}_n(F;S).
+$$
+
+The factor `2` is specific to this repository's absolute-value definition.
+The corresponding one-sided theorem has factor `L`.
+-/
+
+/-- Main contraction example for a centered supervised loss. -/
+example
+    {𝒴 : Type*} [Fintype H] [Nonempty H]
+    (F : H → 𝒵 → ℝ) (loss : ℝ → 𝒴 → ℝ)
+    (S : Fin n → 𝒵 × 𝒴) {L : ℝ} (hL : 0 ≤ L)
+    (hloss : ∀ y u v, |loss u y - loss v y| ≤ L * |u - v|) :
+    empiricalRademacherComplexity n
+        (supervisedLossClass F (centeredLoss loss)) S ≤
+      2 * L *
+        empiricalRademacherComplexity n
+          (fun (h : H) (z : 𝒵 × 𝒴) ↦ F h z.1) S := by
+  exact empiricalRademacherComplexity_centered_supervisedLossClass_le
+    n F loss S hL hloss
 
 end

--- a/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Generalization.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/Generalization.lean
@@ -271,8 +271,8 @@ theorem supervised_approxERM_excessRisk_tail_bound_of_empirical_complexity
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/KernelPredictor.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/KernelPredictor.lean
@@ -168,8 +168,8 @@ theorem finite_rkhs_approxERM_excessRisk_tail_bound_delta
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/KernelPredictor.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalRiskMinimization/KernelPredictor.lean
@@ -165,4 +165,74 @@ theorem finite_rkhs_approxERM_excessRisk_tail_bound_delta
       hC gstar hδ hδ_one
   simpa only [lossClass, predictor, C, Function.comp_apply] using htail
 
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+For a finite collection of weights in an RKHS ball, the finite-class
+contraction theorem also connects a centered Lipschitz loss to the kernel
+trace estimate.  If the loss vanishes at zero, then
+
+$$
+\widehat{\mathfrak R}_n(\ell\circ F;S)
+\le
+2L\,\frac{\Lambda}{n}
+\sqrt{\sum_k K(x_k,x_k)}
+$$
+
+Combining this with the approximate-ERM oracle inequality yields an excess
+risk statement.  The finiteness assumption here belongs to the currently
+proved contraction theorem; the RKHS trace estimate itself applies to the
+entire Hilbert ball.
+-/
+
+/-- RKHS, Lipschitz-loss, and approximate-ERM end-to-end example. -/
+example
+    [MeasurableSpace (𝒳 × 𝒴)] [Nonempty (𝒳 × 𝒴)]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (Φ : 𝒳 → E)
+    (Λ r : ℝ) (hΛ : 0 < Λ) (hr : 0 < r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (weights : G → Metric.closedBall (0 : E) Λ)
+    (loss : ℝ → 𝒴 → ℝ)
+    {L b η : ℝ} (hL : 0 ≤ L)
+    (hloss_zero : ∀ y, loss 0 y = 0)
+    (hloss_lip : ∀ y u v, |loss u y - loss v y| ≤ L * |u - v|)
+    (hclass_meas :
+      ∀ g, Measurable
+        (supervisedLossClass
+          (fun g x ↦ rkhsPredictor Φ (weights g) x) loss g))
+    (hb : 0 < b)
+    (hclass_bound :
+      ∀ g z,
+        |supervisedLossClass
+          (fun g x ↦ rkhsPredictor Φ (weights g) x) loss g z| ≤ b)
+    (Z : Ω → 𝒳 × 𝒴) (hZ : Measurable Z)
+    (A : (Fin n → 𝒳 × 𝒴) → G)
+    (hA : ∀ S,
+      IsApproxERM η n
+        (supervisedLossClass
+          (fun g x ↦ rkhsPredictor Φ (weights g) x) loss)
+        S (A S))
+    (gstar : G) {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      4 *
+          (2 * L *
+            (Λ * (n : ℝ)⁻¹ *
+              Real.sqrt
+                (kernelTrace Φ (fun k ↦ (Z (S k)).1)))) +
+          6 * sampleConfidenceRadius b δ n + η ≤
+        excessRisk
+          (supervisedLossClass
+            (fun g x ↦ rkhsPredictor Φ (weights g) x) loss)
+          μ Z (A (Z ∘ S)) gstar}).toReal ≤ δ := by
+  exact finite_rkhs_approxERM_excessRisk_tail_bound_delta
+    hn Φ Λ r hΛ hr hdiag weights loss hL hloss_zero hloss_lip
+    hclass_meas hb hclass_bound Z hZ A hA gstar hδ hδ_one
+
 end

--- a/StatsMLlib/LearningTheory/FunctionClass/KernelPredictor.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/KernelPredictor.lean
@@ -348,4 +348,94 @@ theorem rkhs_uniformDeviation_tail_bound_kernelTrace_delta
     hδ hδ_one
 
 
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+## Feature-map RKHS predictors
+
+Let $\Phi:\mathcal X\to\mathcal H$ map into a real Hilbert space and define
+
+$$
+K(x,y)=\langle\Phi(x),\Phi(y)\rangle,
+\qquad
+f_w(x)=\langle w,\Phi(x)\rangle,
+\qquad
+\lVert w\rVert\le\Lambda.
+$$
+
+The sample-dependent form of Mohri, Rostamizadeh, and Talwalkar,
+Theorem 6.12 retains the observed kernel trace:
+
+$$
+\Pr\!\left\{
+  \operatorname{UD}_n
+  \ge \frac{2\Lambda}{n}
+      \sqrt{\sum_k K(X_k,X_k)}
+    +3r\Lambda\sqrt{\frac{2\log(2/\delta)}{n}}
+\right\}\le\delta.
+$$
+-/
+
+/-- Main RKHS example retaining the observed kernel trace. -/
+example
+    [Nonempty 𝒳]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (Φ : 𝒳 → H) (hΦ : Measurable Φ)
+    (Λ r : ℝ) (hΛ : 0 < Λ) (hr : 0 < r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * (Λ * (n : ℝ)⁻¹ * Real.sqrt (kernelTrace Φ (X ∘ S))) +
+          3 * ((r * Λ) *
+            Real.sqrt (2 * Real.log (2 / δ) / n)) ≤
+        uniformDeviation n
+          (rkhsPredictor Φ :
+            Metric.closedBall (0 : H) Λ → 𝒳 → ℝ)
+          μ X (X ∘ S)}).toReal ≤ δ := by
+  exact rkhs_uniformDeviation_tail_bound_kernelTrace_delta
+    hn Φ hΦ Λ r hΛ hr hdiag X hX hδ hδ_one
+
+/-!
+Replacing every diagonal value by $K(x,x)\le r^2$ gives the deterministic
+endpoint
+
+$$
+\Pr\!\left\{
+  \operatorname{UD}_n
+  \ge \frac{2r\Lambda}{\sqrt n}
+    +r\Lambda\sqrt{\frac{2\log(1/\delta)}{n}}
+\right\}\le\delta.
+$$
+
+Completeness records the Hilbert-space interpretation; separability is used
+only when the bounded weight ball is reduced to a countable dense subclass.
+-/
+
+/-- Main RKHS example using only a uniform kernel-diagonal bound. -/
+example
+    [Nonempty 𝒳]
+    [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    (Φ : 𝒳 → H) (hΦ : Measurable Φ)
+    (Λ r : ℝ) (hΛ : 0 < Λ) (hr : 0 < r)
+    (hdiag : ∀ x, kernelOfFeatureMap Φ x x ≤ r ^ 2)
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * (r * Λ / Real.sqrt (n : ℝ)) +
+          (r * Λ) * Real.sqrt (2 * Real.log (1 / δ) / n) ≤
+        uniformDeviation n
+          (rkhsPredictor Φ :
+            Metric.closedBall (0 : H) Λ → 𝒳 → ℝ)
+          μ X (X ∘ S)}).toReal ≤ δ := by
+  exact rkhs_uniformDeviation_tail_bound_delta
+    hn Φ hΦ Λ r hΛ hr hdiag X hX hδ hδ_one
+
 end Generalization

--- a/StatsMLlib/LearningTheory/FunctionClass/KernelPredictor.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/KernelPredictor.lean
@@ -350,8 +350,8 @@ theorem rkhs_uniformDeviation_tail_bound_kernelTrace_delta
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L1.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L1.lean
@@ -1071,8 +1071,8 @@ theorem linear_predictor_l1_uniform_deviation_tail_bound_of_sample_delta
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L1.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L1.lean
@@ -1069,4 +1069,51 @@ theorem linear_predictor_l1_uniform_deviation_tail_bound_of_sample_delta
       hδ hδ_one
 
 
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+## `ℓ₁/ℓ∞` linear predictors
+
+For $\lVert w\rVert_1\le W$ and $\lVert x\rVert_\infty\le X_\infty$, let
+
+$$
+Q_\infty(S)
+=\frac1n\sup_{j<d}\sqrt{\sum_k |S_{k,j}|^2}.
+$$
+
+The sample-dependent estimate is
+
+$$
+\Pr\!\left\{
+  \operatorname{UD}_n
+  \ge 2WQ_\infty(S)\sqrt{2\log(2d)}
+    +3X_\infty W\sqrt{\frac{2\log(2/\delta)}{n}}
+\right\}\le\delta.
+$$
+-/
+
+/-- Main sample-dependent example for the `ℓ₁/ℓ∞` linear class. -/
+example
+    [IsProbabilityMeasure μ]
+    (d : ℕ) (Xinf W : ℝ) (hX : 0 < Xinf) (hW : 0 < W)
+    (hd : 0 < d) (hn : 0 < n)
+    (Z : Ω → LinftyBall (d := d) Xinf) (hZ : Measurable Z)
+    {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 *
+          (W * linearPredictorL1SampleRadius (Z ∘ S) *
+            Real.sqrt (2 * Real.log (2 * d))) +
+        3 * ((Xinf * W) * Real.sqrt (2 * Real.log (2 / δ) / n)) ≤
+          uniformDeviation n
+            (linearPredictorL1 :
+              L1Ball (d := d) W → LinftyBall (d := d) Xinf → ℝ)
+            μ Z (Z ∘ S)}).toReal ≤ δ := by
+  exact linear_predictor_l1_uniform_deviation_tail_bound_of_sample_delta
+    d Xinf W hX hW hd hn Z hZ hδ hδ_one
+
 end Generalization

--- a/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L2.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L2.lean
@@ -675,4 +675,79 @@ theorem linear_predictor_l2_uniform_deviation_tail_bound_of_sample_delta
       hδ hδ_one
   simpa only [Function.comp_apply] using htail
 
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+## `ℓ₂` linear predictors
+
+For weights with $\lVert w\rVert_2\le W$ and inputs with
+$\lVert x\rVert_2\le X$, the deterministic end-to-end estimate is
+
+$$
+\Pr\!\left\{
+  \operatorname{UD}_n
+  \ge \frac{2XW}{\sqrt n}
+    +XW\sqrt{\frac{2\log(1/\delta)}{n}}
+\right\}\le\delta.
+$$
+
+`linear_predictor_l2_uniform_deviation_tail_bound_delta` obtains this result
+by composing the fixed-sample linear estimate with the generic bridge.
+-/
+
+/-- Main deterministic-threshold example for the `ℓ₂` linear class. -/
+example
+    [IsProbabilityMeasure μ]
+    (d : ℕ) (W X : ℝ) (hn : 0 < n) (hX : 0 < X) (hW : 0 < W)
+    (Z : Ω → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X)
+    (hZ : Measurable Z) {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * (X * W / Real.sqrt (n : ℝ)) +
+          (X * W) * Real.sqrt (2 * Real.log (1 / δ) / n) ≤
+        uniformDeviation n
+          (linearPredictorL2 :
+            Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+              Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ)
+          μ Z (Z ∘ S)}).toReal ≤ δ := by
+  exact linear_predictor_l2_uniform_deviation_tail_bound_delta
+    d W X hn hX hW Z hZ hδ hδ_one
+
+/-!
+The sample-dependent variant retains the observed quadratic radius:
+
+$$
+\Pr\!\left\{
+  \operatorname{UD}_n
+  \ge \frac{2W}{n}\sqrt{\sum_k\lVert Z_k\rVert_2^2}
+    +3XW\sqrt{\frac{2\log(2/\delta)}{n}}
+\right\}\le\delta.
+$$
+-/
+
+/-- Main sample-dependent example for the `ℓ₂` linear class. -/
+example
+    [IsProbabilityMeasure μ]
+    (d : ℕ) (W X : ℝ) (hn : 0 < n) (hX : 0 < X) (hW : 0 < W)
+    (Z : Ω → Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X)
+    (hZ : Measurable Z) {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 *
+          (W * (n : ℝ)⁻¹ *
+            Real.sqrt
+              (∑ k : Fin n,
+                ‖(Z (S k) : EuclideanSpace ℝ (Fin d))‖ ^ 2)) +
+        3 * ((X * W) * Real.sqrt (2 * Real.log (2 / δ) / n)) ≤
+          uniformDeviation n
+            (linearPredictorL2 :
+              Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) W →
+                Metric.closedBall (0 : EuclideanSpace ℝ (Fin d)) X → ℝ)
+            μ Z (Z ∘ S)}).toReal ≤ δ := by
+  exact linear_predictor_l2_uniform_deviation_tail_bound_of_sample_delta
+    d W X hn hX hW Z hZ hδ hδ_one
+
 end Generalization

--- a/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L2.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L2.lean
@@ -677,8 +677,8 @@ theorem linear_predictor_l2_uniform_deviation_tail_bound_of_sample_delta
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/Rademacher/Dudley.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Dudley.lean
@@ -1993,8 +1993,8 @@ theorem uniform_deviation_tail_bound_separable_of_dudley_delta
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/Rademacher/Dudley.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Dudley.lean
@@ -1992,4 +1992,58 @@ theorem uniform_deviation_tail_bound_separable_of_dudley_delta
       hδ hδ_one
 
 
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+## Dudley entropy integral
+
+For
+
+$$
+D_\alpha(F,S)
+=4\alpha+\frac{12}{\sqrt n}
+  \int_\alpha^{c/2}\sqrt{\log N(F\cup(-F),x)}\,dx,
+$$
+
+the entropy route ends in the directly usable statement
+
+$$
+\Pr\!\left\{
+  \operatorname{UD}_n(F;S)
+  \ge 2D_\alpha(F,S)
+    +3b\sqrt{\frac{2\log(2/\delta)}{n}}
+\right\}\le\delta.
+$$
+
+No sample-uniform deterministic upper bound on the entropy integral is
+required in this form.
+-/
+
+/-- Main sample-dependent Dudley entropy-integral example. -/
+example
+    [MeasurableSpace 𝒳] [Nonempty 𝒳]
+    [TopologicalSpace ι] [SeparableSpace ι] [FirstCountableTopology ι]
+    [IsProbabilityMeasure μ]
+    (F : ι → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b c α : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hn : 0 < n) (hα : 0 < α) (hαc : α < c / 2)
+    (htb : ∀ S : Fin n → 𝒳,
+      TotallyBounded (Set.univ : Set (EmpiricalFunctionSpace F S)))
+    (hnorm : ∀ (S : Fin n → 𝒳) (h : ι), empiricalNorm S (F h) ≤ c)
+    {δ : ℝ} (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * dudleyEntropyEstimate F (X ∘ S) (htb (X ∘ S)) α c +
+        3 * (b * Real.sqrt (2 * Real.log (2 / δ) / n)) ≤
+          uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  exact uniform_deviation_tail_bound_separable_of_dudley_delta
+    F hF_meas X hX hb hF_bound hF_cont hn hα hαc
+    htb hnorm hδ hδ_one
+
 end Generalization

--- a/StatsMLlib/LearningTheory/Rademacher/FiniteClass.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/FiniteClass.lean
@@ -252,4 +252,44 @@ theorem uniform_deviation_tail_bound_finite_of_dudley_quarter_delta
   · exact hδ
   · exact hδ_one
 
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+For a finite hypothesis class, taking every hypothesis as a cover center gives
+$N(F^\pm,\varepsilon)\leq2|H|$.  Choosing $\alpha=c/4$ in Dudley's estimate
+removes the covering number completely:
+
+$$
+\widehat{\mathfrak R}_n(F;S)
+\leq
+c+\frac{3c}{\sqrt n}\sqrt{\log(2|H|)}.
+$$
+
+The following high-probability example has no unevaluated entropy term.
+-/
+
+/-- Explicit finite-class Dudley generalization bound. -/
+example
+    [MeasurableSpace 𝒳] [Nonempty 𝒳]
+    [Fintype H] [Nonempty H] [IsProbabilityMeasure μ]
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b c δ : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hn : 0 < n) (hc : 0 < c)
+    (hNorm : ∀ (S : Fin n → 𝒳) h, empiricalNorm S (F h) ≤ c)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 *
+          (c + (3 * c / Real.sqrt n) *
+            Real.sqrt (Real.log (2 * Fintype.card H))) +
+          3 * sampleConfidenceRadius b δ n ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  exact uniform_deviation_tail_bound_finite_of_dudley_quarter_delta
+    F hF_meas X hX hb hF_bound hn hc hNorm hδ hδ_one
+
 end

--- a/StatsMLlib/LearningTheory/Rademacher/FiniteClass.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/FiniteClass.lean
@@ -255,8 +255,8 @@ theorem uniform_deviation_tail_bound_finite_of_dudley_quarter_delta
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/Rademacher/LipschitzParameter.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/LipschitzParameter.lean
@@ -414,4 +414,51 @@ theorem uniform_deviation_tail_bound_lipschitzParameter_dudley_delta
   · exact hδ
   · exact hδ_one
 
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+For a continuously parameterized family $F_t$, $t\in[-W,W]$, satisfying
+
+$$
+|F_t(x)-F_s(x)|\leq L|t-s|,
+$$
+
+an equally spaced grid gives
+
+$$
+N(F,\varepsilon)
+\leq
+\left\lceil\frac{2WL}{\varepsilon}\right\rceil+1.
+$$
+
+Freezing this estimate at the Dudley truncation scale $\alpha$ yields the
+following confidence bound, again with no unevaluated covering number.
+-/
+
+/-- Explicit Dudley generalization bound for a Lipschitz parameter family. -/
+example
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [IsProbabilityMeasure μ]
+    (hn : 0 < n)
+    {W L : ℝ} (hW : 0 ≤ W) (hL : 0 < L)
+    (F : Set.Icc (-W) W → 𝒳 → ℝ)
+    (hF_meas : ∀ t, Measurable (F t))
+    (hF_lip : ∀ t s x, |F t x - F s x| ≤ L * |t.1 - s.1|)
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b c α δ : ℝ} (hb : 0 < b) (hF_bound : ∀ t x, |F t x| ≤ b)
+    (hα : 0 < α) (hαc : α < c / 2)
+    (hNorm : ∀ (S : Fin n → 𝒳) t, empiricalNorm S (F t) ≤ c)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * lipschitzParameterDudleyEstimate n W L α c +
+          3 * sampleConfidenceRadius b δ n ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  exact uniform_deviation_tail_bound_lipschitzParameter_dudley_delta
+    hn hW hL F hF_meas hF_lip X hX hb hF_bound
+    hα hαc hNorm hδ hδ_one
+
 end

--- a/StatsMLlib/LearningTheory/Rademacher/LipschitzParameter.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/LipschitzParameter.lean
@@ -417,8 +417,8 @@ theorem uniform_deviation_tail_bound_lipschitzParameter_dudley_delta
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
@@ -720,8 +720,8 @@ theorem uniform_deviation_tail_bound_separable_of_sample_empirical_le
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 /-!

--- a/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
@@ -717,4 +717,48 @@ theorem uniform_deviation_tail_bound_separable_of_sample_empirical_le
     _ ≤ _ :=
       uniform_deviation_tail_bound_separable_of_empirical_complexity
         (μ := μ) F hF_meas X hX hb hF_bound hF_cont hε
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+/-!
+## The observed empirical complexity
+
+The basic sample-dependent theorem keeps the empirical Rademacher complexity
+of the observed sample in the threshold:
+
+$$
+\Pr\!\left\{
+  \operatorname{UD}_n(F;S)
+  \ge 2\widehat{\mathfrak R}_n(F;S)+3\varepsilon
+\right\}
+\le
+2\exp\!\left(-\frac{n\varepsilon^2}{2b^2}\right).
+$$
+
+Thus this single statement exhibits the three commonly used variants
+requested at once: a separable hypothesis class, a high-probability estimate,
+and empirical rather than expected Rademacher complexity.
+-/
+
+/-- Basic separable high-probability bound using observed empirical complexity. -/
+example
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    {ε : ℝ} (hε : 0 ≤ ε) :
+    (μⁿ {S : Fin n → Ω |
+      2 * empiricalRademacherComplexity n F (X ∘ S) + 3 * ε ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤
+      2 * (-ε ^ 2 * n / (2 * b ^ 2)).exp := by
+  exact uniform_deviation_tail_bound_separable_of_empirical_complexity
+    (μ := μ) F hF_meas X hX hb hF_bound hF_cont hε
+
 end

--- a/StatsMLlib/LearningTheory/UniformDeviation/Confidence.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Confidence.lean
@@ -245,8 +245,8 @@ theorem uniform_deviation_tail_bound_separable_of_sample_empirical_le_delta
 
 /-! ## Examples
 
-Acceptance examples for the public API of this module, distributed here from
-upstream's `FoML/Main.lean` per plan §13.6.
+Worked uses of this module's public API. They are elaborated with the library, so they
+double as acceptance tests that these statements stay usable as written.
 -/
 
 example

--- a/StatsMLlib/LearningTheory/UniformDeviation/Confidence.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Confidence.lean
@@ -242,4 +242,28 @@ theorem uniform_deviation_tail_bound_separable_of_sample_empirical_le_delta
     _ = δ :=
       two_mul_exp_neg_sampleConfidenceRadius_sq hn hb hδ hδ_one
 
+
+/-! ## Examples
+
+Acceptance examples for the public API of this module, distributed here from
+upstream's `FoML/Main.lean` per plan §13.6.
+-/
+
+example
+    [MeasurableSpace 𝒳] [Nonempty 𝒳] [Nonempty H]
+    [TopologicalSpace H] [SeparableSpace H] [FirstCountableTopology H]
+    [IsProbabilityMeasure μ]
+    (F : H → 𝒳 → ℝ) (hF_meas : ∀ h, Measurable (F h))
+    (X : Ω → 𝒳) (hX : Measurable X)
+    {b C δ : ℝ} (hb : 0 < b) (hF_bound : ∀ h x, |F h x| ≤ b)
+    (hF_cont : ∀ x : 𝒳, Continuous fun h ↦ F h x)
+    (hn : 0 < n)
+    (hC : ∀ S : Fin n → 𝒳, empiricalRademacherComplexity n F S ≤ C)
+    (hδ : 0 < δ) (hδ_one : δ ≤ 1) :
+    (μⁿ {S : Fin n → Ω |
+      2 * C + b * Real.sqrt (2 * Real.log (1 / δ) / n) ≤
+        uniformDeviation n F μ X (X ∘ S)}).toReal ≤ δ := by
+  exact uniform_deviation_tail_bound_separable_of_empirical_le_delta
+    (μ := μ) hn F hF_meas X hX hb hF_bound hF_cont hC hδ hδ_one
+
 end


### PR DESCRIPTION
Thirteen worked `example`s are added to the ends of the modules whose API they exercise,
under an `## Examples` heading, and `README.md` gains a table naming the endpoint of each
generalization route.

The examples are elaborated with the library, so they double as acceptance tests: if a
statement stops being usable as written, the build fails.

## Where they went

| Module | # |
|---|---:|
| `UniformDeviation/Bounds` | 1 |
| `UniformDeviation/Confidence` | 1 |
| `FunctionClass/LinearPredictor/L2` | 2 |
| `FunctionClass/LinearPredictor/L1` | 1 |
| `FunctionClass/KernelPredictor` | 2 |
| `Rademacher/Dudley` | 1 |
| `Rademacher/FiniteClass` | 1 |
| `Rademacher/LipschitzParameter` | 1 |
| `EmpiricalRiskMinimization/Generalization` | 2 |
| `EmpiricalRiskMinimization/KernelPredictor` | 1 |

Each example lives in the module that owns the endpoint it demonstrates, which is what
lets it compile there: an example naming a δ-form bound belongs with the δ forms, one
naming a finite-class bound belongs with the finite-class results, and so on.

## The README table

Ten rows, one per generalization route — countable and separable classes, `ℓ₂` and
`ℓ₁/ℓ∞` linear predictors, feature-map RKHS predictors, the Dudley entropy route, finite
and Lipschitz-parametrized families, and approximate ERM with and without an RKHS ball.
Each names the module and the endpoint theorem.

**Every declaration named in the table was checked to exist.** One draft name
(`approxERM_excessRisk_tail_bound_delta`) did not, and was corrected to
`approxERM_excessRisk_tail_bound_separable_of_sample_empirical_le_delta`.

## Supporting change

`EmpiricalRiskMinimization/Generalization.lean` gains
`import StatsMLlib.LearningTheory.Rademacher.Contraction`, needed by its Lipschitz-loss
example. No cycle: `Contraction` imports only `EmpiricalRiskMinimization/Defs` and
`Rademacher/Signs`.

Instance binders already supplied at file level are omitted from the examples, which
`linter.overlappingInstances` requires.

## Verification

- `lake build` green across all 8811 jobs, changed files touched first so they really
  rebuild, and **no warnings** in the build output.
- All thirteen examples elaborate; that is the acceptance test.
- `rg -n '\b(sorry|admit|native_decide)\b|^axiom ' StatsMLlib/` — nothing.
- 577 added lines, within the repository's per-PR guideline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
