### PR TITLE
Drop the unused signed-coordinate index type

### DIFF
--- a/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L1.lean
+++ b/StatsMLlib/LearningTheory/FunctionClass/LinearPredictor/L1.lean
@@ -57,14 +57,6 @@ lemma abs_boolSign (b : Bool) : |boolSign b| = 1 := by
 noncomputable def coordSigned (jb : Fin d × Bool) (x : EuclideanSpace ℝ (Fin d)) : ℝ :=
   boolSign jb.2 * x jb.1
 
--- restriction to a finite set via Massart's F_on (we take univ)
-abbrev CoordIndex (d : Nat) :=
-  { jb : Fin d × Bool // jb ∈ (Finset.univ : Finset (Fin d × Bool)) }
-
-noncomputable def coordSignedOn (x : EuclideanSpace ℝ (Fin d)) :
-    CoordIndex d → ℝ :=
-  fun jb => coordSigned (d := d) jb.1 x
-
 -- helper: |sum_j w_j z_j| ≤ (∑|w_j|)*M if |z_j|≤M
 lemma abs_sum_mul_le_l1_mul {w z : EuclideanSpace ℝ (Fin d)} {M : ℝ}
     (hM : ∀ j : Fin d, |z j| ≤ M) :


### PR DESCRIPTION
Deletion only. One file, eight lines removed, nothing else changed.

## What is removed

```lean
-- restriction to a finite set via Massart's F_on (we take univ)
abbrev CoordIndex (d : Nat) :=
  { jb : Fin d × Bool // jb ∈ (Finset.univ : Finset (Fin d × Bool)) }

noncomputable def coordSignedOn (x : EuclideanSpace ℝ (Fin d)) :
    CoordIndex d → ℝ :=
  fun jb => coordSigned (d := d) jb.1 x
```

`CoordIndex d` is a subtype of `Fin d × Bool` carrying membership in `Finset.univ`, which
excludes nothing, so it is that product with an extra projection in the way.
`coordSignedOn` is `coordSigned` composed with that projection.

## Why

Neither is referenced anywhere in the library — `rg` over `StatsMLlib/` finds only the
definitions and their mutual mention.

Meanwhile the module spells `Fin d × Bool` directly in **50** places and uses
`coordSigned` in **54**. Naming the index type a second way and then never using the name
only invites a reader to look for a distinction between `CoordIndex d` and `Fin d × Bool`
that does not exist. The comment suggests these were an attempt to route through
Massart's `F_on` on a restricted index set; the proofs took the direct route instead.

The alternative — switching the fifty call sites to `CoordIndex` — would spread a subtype
that constrains nothing and force a `.1` at each use, which is exactly what
`coordSignedOn` had to do.

## Verification

- `lake build` green across all 8811 jobs, changed file touched first so it really
  rebuilds, and no warnings.
- `rg -n 'CoordIndex|coordSignedOn' StatsMLlib/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
