### PR TITLE
Remove three unreferenced declarations

### DIFF
--- a/StatsMLlib/Analysis/MetricEntropy/Basic.lean
+++ b/StatsMLlib/Analysis/MetricEntropy/Basic.lean
@@ -18,7 +18,7 @@ Two-level design: ENNReal `entropyIntegralENNReal` (canonical) with real wrapper
 
 ## Main definitions
 
-* `metricEntropy` / `metricEntropyENNReal`: log N(ε, s)
+* `metricEntropy`: log N(ε, s)
 * `dudleyIntegrand`: √log N(ε, s) as ENNReal
 * `entropyIntegralENNReal`: ∫₀^D √log N(ε, s) dε (canonical)
 * `entropyIntegral`: Real-valued wrapper via `.toReal`
@@ -397,20 +397,15 @@ lemma sum_shifted_le_two_sum {f : ℕ → ℝ} (hf : ∀ k, 0 ≤ f k) (K : ℕ)
     _ = 2 * ∑ k ∈ Finset.range (K + 2), f k := by ring
 
 /-!
-## ENNReal Metric Entropy and Dudley Integrand
+## Dudley Integrand
 -/
-
-/-- Metric entropy as ENNReal: max(0, log N(ε, s)).
-    This is the non-negative part of the logarithm of the covering number. -/
-def metricEntropyENNReal (eps : ℝ) (s : Set A) : ℝ≥0∞ :=
-  ENNReal.ofReal (metricEntropy eps s)
 
 /-- Dudley integrand: √(log N(ε, s)), as ENNReal.
     This is the integrand for Dudley's entropy integral. -/
 def dudleyIntegrand (eps : ℝ) (s : Set A) : ℝ≥0∞ :=
   ENNReal.ofReal (sqrtEntropy eps s)
 
-lemma dudleyIntegrand_eq_sqrt_metricEntropyENNReal (eps : ℝ) (s : Set A) :
+lemma dudleyIntegrand_eq_ofReal_sqrt_metricEntropy (eps : ℝ) (s : Set A) :
     dudleyIntegrand eps s = ENNReal.ofReal (Real.sqrt (metricEntropy eps s)) := rfl
 
 /-- Dudley integrand is monotone in epsilon (anti-monotone: larger eps → smaller value). -/

--- a/StatsMLlib/LearningTheory/Rademacher/Massart.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Massart.lean
@@ -124,12 +124,9 @@ noncomputable def Y (i : Fin m) (j : ι) : Ωᵣ → ℝ :=
 noncomputable def X (j : ι) : Ωᵣ → ℝ :=
   fun σ => ∑ i : Fin m, Y (F:=F) (S:=S) i j σ
 
--- per-sample envelope r i (independent of j), and its ℓ2-aggregate r′
+-- per-sample envelope r i (independent of j)
 noncomputable def r (f : Finset ι) (hs : f.Nonempty) (i : Fin m) : ℝ :=
   (m : ℝ)⁻¹ * Finset.sup' f hs (fun j => |F j (S i)|)
-
-noncomputable def r' (i : Fin m) (j : ι) : ℝ :=
-  (m : ℝ)⁻¹ * |F j (S i)|
 
 end MassartNotation
 

--- a/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
+++ b/StatsMLlib/LearningTheory/UniformDeviation/Bounds.lean
@@ -136,7 +136,6 @@ theorem uniform_deviation_tail_bound_countable_of_pos
     (μⁿ (fun ω ↦ 2 * rademacherComplexity n f μ X + ε ≤ uniformDeviation n f μ X (X ∘ ω))).toReal ≤
       (- ε ^ 2 * n / (2 * b ^ 2)).exp := by
   let t := 1 / (2 * b ^ 2)
-  have ht : 0 ≤ t := div_nonneg (by norm_num) (mul_nonneg (by norm_num) (sq_nonneg b))
   have ht' : t * b ^ 2 ≤ 1 / 2 := le_of_eq (by dsimp only [t]; field_simp)
   calc
     _ ≤ (- ε ^ 2 * t * n).exp :=
@@ -232,7 +231,6 @@ theorem uniform_deviation_tail_bound_separable_of_pos
     (μⁿ (fun ω ↦ 2 * rademacherComplexity n f μ X + ε ≤ uniformDeviation n f μ X (X ∘ ω))).toReal ≤
       (- ε ^ 2 * n / (2 * b ^ 2)).exp := by
   let t := 1 / (2 * b ^ 2)
-  have ht : 0 ≤ t := div_nonneg (by norm_num) (mul_nonneg (by norm_num) (sq_nonneg b))
   have ht' : t * b ^ 2 ≤ 1 / 2 := le_of_eq (by dsimp only [t]; field_simp)
   calc
     _ ≤ (- ε ^ 2 * t * n).exp :=


### PR DESCRIPTION
Three declarations that nothing referenced. Net −10 lines.

## `metricEntropyENNReal`

Defined as `ENNReal.ofReal (metricEntropy eps s)`. It had **no users**: its only
three mentions in the library were the module docstring, its own definition, and a
lemma that borrowed its name without mentioning it.

That lemma states

```lean
dudleyIntegrand eps s = ENNReal.ofReal (Real.sqrt (metricEntropy eps s))
```

`ENNReal.ofReal` of a real square root — not the square root of `metricEntropyENNReal`,
which is what the name `dudleyIntegrand_eq_sqrt_metricEntropyENNReal` promises. Renamed
to `dudleyIntegrand_eq_ofReal_sqrt_metricEntropy`, which is what it proves. It stays
`rfl`.

## `MassartNotation.r'`

Defined, never referenced. The `r'` in `Rademacher/Dudley.lean:973` is an unrelated
local `have` inside a proof. Its sibling `MassartNotation.r` is used and stays; the
comment above the pair drops its mention of `r′`.

## An unused local hypothesis, twice

`uniform_deviation_tail_bound_countable_of_pos` and
`uniform_deviation_tail_bound_separable_of_pos` each open with

```lean
have ht : 0 ≤ t := div_nonneg (by norm_num) (mul_nonneg (by norm_num) (sq_nonneg b))
```

Neither proof uses it — both close through `ht'` and `hε`. Removed from both.

## Verification

- `lake build` green across all jobs, no warnings.
- No statement or signature changes: every remaining declaration proves the same thing,
  with `dudleyIntegrand_eq_ofReal_sqrt_metricEntropy` the only renamed one, and it had
  no call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
