### PR TITLE
Remove eight redundant declarations

### DIFF
--- a/StatsMLlib/Analysis/MetricEntropy/Basic.lean
+++ b/StatsMLlib/Analysis/MetricEntropy/Basic.lean
@@ -521,12 +521,6 @@ lemma entropyIntegral_mono_set_of_totallyBounded {s₁ s₂ : Set A} {D : ℝ}
   intro eps heps _
   exact coveringNumber_lt_top_of_totallyBounded heps hs₂
 
-/-- Entropy integral is monotone in D for totally bounded sets (with finiteness). -/
-lemma entropyIntegral_mono_D_of_totallyBounded {s : Set A} {D₁ D₂ : ℝ}
-    (hD : D₁ ≤ D₂)
-    (hfinite₂ : entropyIntegralENNReal s D₂ ≠ ⊤) :
-    entropyIntegral s D₁ ≤ entropyIntegral s D₂ :=
-  entropyIntegral_mono_D hD hfinite₂
 
 /-!
 ## Integrability and Real-ENNReal Connection

--- a/StatsMLlib/LearningTheory/EmpiricalProcess/FunctionClass.lean
+++ b/StatsMLlib/LearningTheory/EmpiricalProcess/FunctionClass.lean
@@ -40,10 +40,6 @@ lemma empiricalNorm_def (S : Fin n → 𝒳) (f : 𝒳 → ℝ) :
 noncomputable def empiricalDist (S : Fin n → 𝒳) (f g : 𝒳 → ℝ) : ℝ :=
   empiricalNorm S (f - g)
 
-@[simp]
-lemma empiricalDist_def (S : Fin n → 𝒳) (f g : 𝒳 → ℝ) :
-    empiricalDist S f g = empiricalNorm S (f - g) :=
-  rfl
 
 @[reducible] noncomputable def empiricalPMet (S : Fin n → 𝒳) :
     PseudoMetricSpace (𝒳 → ℝ) :=

--- a/StatsMLlib/LearningTheory/Rademacher/Complexity.lean
+++ b/StatsMLlib/LearningTheory/Rademacher/Complexity.lean
@@ -792,26 +792,13 @@ theorem integrable_norm_sup_abs_sum_sub [Nonempty ι] [Countable ι] {X : Ω →
   simp only [abs_abs]
   apply bounded_difference_of_bounded hf'
 
-theorem measurable_signed_sup_sum_prod_fst [Countable ι] {X : Ω → Z} (hf : ∀ (i : ι), Measurable (f i ∘ X)) :
-    Measurable (fun ω : (Fin n → Ω) × (Fin n → Ω) ↦ (↑(Fintype.card (Signs n)))⁻¹ * ∑ σ : Signs n, ⨆ i, |∑ k : Fin n, ↑↑(σ k) * f i (X (ω.1 k))|) := by
-  apply Measurable.mul measurable_const
-  apply Finset.univ.measurable_sum
-  intro σ _
-  apply Measurable.iSup
-  intro i
-  apply Measurable.abs
-  apply Finset.univ.measurable_sum
-  intro k _
-  apply measurable_const.mul
-  apply (hf i).comp
-  apply measurable_fst.eval
 
 theorem integrable_signed_sup_sum_prod_fst [Nonempty ι] [Countable ι] {X : Ω → Z} (hf : ∀ (i : ι), Measurable (f i ∘ X))
     {b : ℝ} (hf' : ∀ (i : ι) (z : Z), |f i z| ≤ b) :
     Integrable (fun ω : (Fin n → Ω) × (Fin n → Ω) ↦ (↑(Fintype.card (Signs n)))⁻¹ * ∑ σ : Signs n, ⨆ i, |∑ k : Fin n, ↑↑(σ k) * f i (X (ω.1 k))|)
       (μⁿ.prod μⁿ) := by
   simp_rw [← memLp_one_iff_integrable]
-  apply MemLp.of_bound (measurable_signed_sup_sum_prod_fst hf).aestronglyMeasurable (n * b)
+  apply MemLp.of_bound (measurable_signed_sup_sum_fst hf).aestronglyMeasurable (n * b)
   filter_upwards with ω
   simp only [Signs.card, Nat.cast_pow, Nat.cast_ofNat, Int.reduceNeg, norm_mul, norm_inv, norm_pow,
     norm_ofNat, norm_eq_abs]

--- a/StatsMLlib/Probability/Concentration/HansonWright.lean
+++ b/StatsMLlib/Probability/Concentration/HansonWright.lean
@@ -4281,60 +4281,6 @@ theorem hanson_wright_inequality {μ : Measure Ω} [IsProbabilityMeasure μ]
         ring
       exact hHW.2 l hl') ht
 
-private lemma hanson_wright_scaled_rhs_le {K C F O t : ℝ} (hK : 0 < K)
-    (hC : 0 < C) (hF : 0 < F) (hO : 0 < O) (ht : 0 ≤ t) :
-    2 * exp (-(1 / (4 * (C / 16))) *
-        min (t ^ 2 / ((2 * K) ^ 4 * F ^ 2))
-          (t / ((2 * K) ^ 2 * O))) ≤
-      2 * exp (-(1 / (4 * C)) *
-        min (t ^ 2 / (K ^ 4 * F ^ 2))
-          (t / (K ^ 2 * O))) := by
-  set q : ℝ := t ^ 2 / (K ^ 4 * F ^ 2) with hq_def
-  set r : ℝ := t / (K ^ 2 * O) with hr_def
-  have hq_nonneg : 0 ≤ q := by
-    rw [hq_def]
-    positivity
-  have hr_nonneg : 0 ≤ r := by
-    rw [hr_def]
-    positivity
-  have hq_scaled :
-      t ^ 2 / ((2 * K) ^ 4 * F ^ 2) = q / 16 := by
-    rw [hq_def]
-    field_simp [hK.ne', hF.ne']
-    ring
-  have hr_scaled :
-      t / ((2 * K) ^ 2 * O) = r / 4 := by
-    rw [hr_def]
-    field_simp [hK.ne', hO.ne']
-    ring
-  have hcoef : 1 / (4 * (C / 16)) = 4 / C := by
-    field_simp [hC.ne']
-    ring
-  have hmin_scaled : min q r / 16 ≤ min (q / 16) (r / 4) := by
-    apply le_min
-    · exact div_le_div_of_nonneg_right (min_le_left q r) (by norm_num)
-    · calc
-        min q r / 16 ≤ r / 16 :=
-          div_le_div_of_nonneg_right (min_le_right q r) (by norm_num)
-        _ ≤ r / 4 := by nlinarith [hr_nonneg]
-  have harg :
-      -(1 / (4 * (C / 16))) *
-        min (t ^ 2 / ((2 * K) ^ 4 * F ^ 2)) (t / ((2 * K) ^ 2 * O)) ≤
-      -(1 / (4 * C)) *
-        min (t ^ 2 / (K ^ 4 * F ^ 2)) (t / (K ^ 2 * O)) := by
-    rw [hq_scaled, hr_scaled, hcoef]
-    change -(4 / C) * min (q / 16) (r / 4) ≤ -(1 / (4 * C)) * min q r
-    have hneg : -(4 / C) ≤ 0 := by
-      have hpos : 0 ≤ 4 / C := by positivity
-      linarith
-    calc
-      -(4 / C) * min (q / 16) (r / 4)
-          ≤ -(4 / C) * (min q r / 16) :=
-            mul_le_mul_of_nonpos_left hmin_scaled hneg
-      _ = -(1 / (4 * C)) * min q r := by
-          field_simp [hC.ne']
-          ring
-  exact mul_le_mul_of_nonneg_left (exp_le_exp.mpr harg) (by norm_num)
 
 /-- Hanson-Wright inequality in the HDP normalization.
 

--- a/StatsMLlib/Probability/Process/SubGaussian.lean
+++ b/StatsMLlib/Probability/Process/SubGaussian.lean
@@ -187,12 +187,6 @@ lemma IsSubGaussian.integrable_exp_mul {Ω : Type*} [MeasurableSpace Ω]
   obtain ⟨_, h_mgf⟩ := h_sg
   exact h_mgf.integrable_exp_mul t
 
-/-- Compatibility name for exponential integrability of sub-Gaussian random variables. -/
-lemma sub_gaussian_integrable {Ω : Type*} [MeasurableSpace Ω]
-    {X : Ω → ℝ} {σ_sq : ℝ} {μ : Measure Ω} [IsFiniteMeasure μ]
-    (h_sg : IsSubGaussian X σ_sq μ) (t : ℝ) :
-    Integrable (fun x => Real.exp (t * X x)) μ :=
-  h_sg.integrable_exp_mul t
 
 /-- A sub-Gaussian real random variable is integrable. -/
 lemma IsSubGaussian.integrable {Ω : Type*} [MeasurableSpace Ω]

--- a/StatsMLlib/Probability/Process/TruncatedDudley.lean
+++ b/StatsMLlib/Probability/Process/TruncatedDudley.lean
@@ -149,7 +149,7 @@ lemma mgf_max_bound {α : Type*} [MeasurableSpace α]
     · refine' MeasureTheory.integral_mono_of_nonneg _ _ _;
       · exact Filter.Eventually.of_forall fun x => Real.exp_nonneg _;
       · refine' MeasureTheory.integrable_finsetSum _ fun i _ => _;
-        exact sub_gaussian_integrable (h_sg i) t;
+        exact (h_sg i).integrable_exp_mul t;
       · filter_upwards [ ] with x;
 
         have h_max_exp : Real.exp (t * ⨆ k, Y k x) ≤ ∑ k, Real.exp (t * Y k x) := by
@@ -160,7 +160,7 @@ lemma mgf_max_bound {α : Type*} [MeasurableSpace α]
                 (Set.nonempty_of_mem <| Set.mem_range_self ⟨0, hM⟩))
           exact le_trans ( by rw [ ← h_max.choose_spec ] ) ( Finset.single_le_sum ( fun k _ => Real.exp_nonneg ( t * Y k x ) ) ( Finset.mem_univ _ ) );
         exact h_max_exp;
-    · exact fun k _ => sub_gaussian_integrable ( h_sg k ) t;
+    · exact fun k _ => (h_sg k).integrable_exp_mul t;
 
   have h_sub_gaussian_bound : ∀ k, ∫ x, Real.exp (t * Y k x) ∂μ ≤ Real.exp (σ_sq * t^2 / 2) := by
     intro k
@@ -204,7 +204,7 @@ lemma metric_entropy_bound_for_sub_gaussian_maxima
           · exact Filter.Eventually.of_forall fun x => Set.mem_univ _;
           · exact h_integrable.const_mul t;
           · have h_integrable_exp : ∀ k, MeasureTheory.Integrable (fun x => Real.exp (t * Y k x)) μ := by
-              exact fun k => sub_gaussian_integrable (h_sg k) t;
+              exact fun k => (h_sg k).integrable_exp_mul t;
             refine' MeasureTheory.Integrable.mono' ( MeasureTheory.integrable_finsetSum _ fun k _ => h_integrable_exp k ) _ _;
             exact Finset.univ;
             · exact Real.continuous_exp.comp_aestronglyMeasurable ( h_integrable.aestronglyMeasurable.const_mul _ );
@@ -517,7 +517,7 @@ lemma expectation_bound_chain_step
           refine' ⟨ _, _ ⟩;
           exact sq_nonneg _;
           refine' ⟨ _, fun t => _ ⟩;
-          · exact fun t => sub_gaussian_integrable h_sg t;
+          · exact fun t => h_sg.integrable_exp_mul t;
           · refine' le_trans ( h_sg.choose_spec.2 t ) _;
             exact Real.exp_le_exp.mpr ( by
               gcongr
@@ -809,24 +809,6 @@ lemma dudley_chain_bound_pointwise
       · exact chain_projection_mem L pi_map v hv h_chain 1 ( by linarith );
     linarith [ h_chain_bound u hu, h_chain_bound v hv, abs_sub_comm ( X v1 ) ( X v ) ]
 
-/-
-Pointwise bound for the difference of a process along a Dudley chain.
--/
-lemma dudley_chain_bound_pointwise_v2
-  {α : Type*}
-  {X : α → ℝ}
-  {L : ℕ} (hL : 1 ≤ L)
-  {U_seq : ℕ → Set α}
-  {pi_map : ℕ → α → α}
-  (hU_finite : ∀ m, (U_seq m).Finite)
-  (h_chain : ∀ m < L, ∀ u ∈ U_seq (m + 1), pi_map m u ∈ U_seq m)
-  (u : α) (hu : u ∈ U_seq L)
-  (v : α) (hv : v ∈ U_seq L)
-  :
-  |X u - X v| ≤
-  (⨆ x ∈ U_seq 1, ⨆ y ∈ U_seq 1, |X x - X y|) +
-  2 * ∑ k ∈ Finset.range (L - 1), (⨆ z ∈ U_seq (k + 2), |X z - X (pi_map (k + 1) z)|) := by
-    convert dudley_chain_bound_pointwise hL hU_finite h_chain u hu v hv using 1
 
 /-
 Linearity of expectation applied to the Dudley chain bound.
@@ -1511,14 +1493,6 @@ lemma dudley_step_bound_tight
           exact Real.sqrt_le_sqrt hmul_le
       nlinarith
 
-lemma dudley_sum_bound_tight
-  {f : ℝ → ℝ}
-  {D : ℝ} (hD : 0 < D)
-  (hf_antitone : AntitoneOn f (Set.Icc 0 D))
-  (L : ℕ) (hL : 1 ≤ L) :
-  ∑ k ∈ Finset.range (L - 1), 4 * (D * 2 ^ (-(k + 1 : ℝ))) * f (D * 2 ^ (-(k + 2 : ℝ))) ≤
-  16 * ∫ x in Set.Icc (D * 2 ^ (-(L + 1 : ℝ))) (D * 2 ^ (-2 : ℝ)), f x := by
-    convert dudley_sum_bound hD hf_antitone L hL using 1
 
 /-
 Entropy integral monotonicity: integrating √(log N(·,T)) over a larger domain gives a larger value.
@@ -1948,7 +1922,7 @@ lemma chaining_entropy_bound
             simp only [heps_def]; push_cast; rfl)
         rw [h_sum_rw]
 
-        have h_sum_bound := dudley_sum_bound_tight hD hg_antitone L hL_ge_1
+        have h_sum_bound := dudley_sum_bound hD hg_antitone L hL_ge_1
 
         have hg_eq_on : ∀ x ∈ Set.Icc (D * 2 ^ (-(↑L + 1 : ℝ))) (D * 2 ^ (-2 : ℝ)),
             g x = Real.sqrt (Real.log (subsetENetCard T x)) := by

--- a/StatsMLlib/Statistics/Regression/LeastSquares/L1/CoveringBound.lean
+++ b/StatsMLlib/Statistics/Regression/LeastSquares/L1/CoveringBound.lean
@@ -1054,12 +1054,6 @@ The empirical image of the localized ball is totally bounded because it's contai
 in a closed ball of finite radius.
 -/
 
-/-- The empirical image of l1LocalizedBall is contained in a closed ball of radius δ -/
-lemma l1EmpiricalImage_subset_closedBall {d : ℕ} {R δ : ℝ} {θ_star : EuclideanSpace ℝ (Fin d)}
-    {x : Fin n → EuclideanSpace ℝ (Fin d)} :
-    l1EmpiricalImage x '' (l1LocalizedBall d R δ θ_star x) ⊆
-    Metric.closedBall (0 : EmpiricalSpace n) δ :=
-  l1LocalizedBallImage_subset
 
 /-- The closed ball in EmpiricalSpace is bounded -/
 lemma EmpiricalSpace_closedBall_bounded (n : ℕ) (r : ℝ) :
@@ -1070,7 +1064,7 @@ lemma EmpiricalSpace_closedBall_bounded (n : ℕ) (r : ℝ) :
 theorem l1LocalizedBallImage_bounded {d : ℕ} {R δ : ℝ}
     {θ_star : EuclideanSpace ℝ (Fin d)} (x : Fin n → EuclideanSpace ℝ (Fin d)) :
     Bornology.IsBounded (l1EmpiricalImage x '' (l1LocalizedBall d R δ θ_star x)) :=
-  Bornology.IsBounded.subset (EmpiricalSpace_closedBall_bounded n δ) l1EmpiricalImage_subset_closedBall
+  Bornology.IsBounded.subset (EmpiricalSpace_closedBall_bounded n δ) l1LocalizedBallImage_subset
 
 /-! ## Localized ℓ₁ Ball Image Covering Bound
 


### PR DESCRIPTION
An audit of all **2,498 declarations** found nine pairs with identical statements. This
removes the eight that are settled by deletion. **7 lines added, 122 removed.**

## Names that promised a difference they did not deliver

The worst kind — not just redundant, actively misleading.

| removed | what it actually was |
|---|---|
| `entropyIntegral_mono_D_of_totallyBounded` | `entropyIntegral_mono_D hD hfinite₂`. **No `TotallyBounded` hypothesis existed.** |
| `dudley_sum_bound_tight` | `convert dudley_sum_bound …`. **Not tighter — the same bound.** |
| `dudley_chain_bound_pointwise_v2` | same statement as `dudley_chain_bound_pointwise`, unused |

## Plain aliases

| removed | survivor |
|---|---|
| `l1EmpiricalImage_subset_closedBall` | `l1LocalizedBallImage_subset` |
| `sub_gaussian_integrable` | `IsSubGaussian.integrable_exp_mul` — its own docstring called it a "compatibility name" |

## A duplicated proof and a duplicated `rfl`

`measurable_signed_sup_sum_prod_fst` re-proved `measurable_signed_sup_sum_fst` — same
statement, thirteen lines apart in the same file, proved again from scratch.

`empiricalDist_def` and `empiricalDist_app` sat eleven lines apart with the same statement
and the same `rfl` proof. `empiricalDist_app` is the `@[simp]` one and stays.

## One unreachable declaration

`hanson_wright_scaled_rhs_le` was `private` and unused — unreachable by construction. **54
lines.**

## Call sites

Six move to the surviving name (`sub_gaussian_integrable` had four, the rest one each).
Every surviving declaration keeps its statement and its proof; the four-argument shapes are
identical, so the redirects are name substitutions.

## Deliberately not in this PR

Two more duplications are real but need a **placement decision**, so they are left for
discussion rather than decided here:

- `sqrt_add_le` (`Statistics/…/IntegralBounds.lean`) and `sqrt_add_le_peeling`
  (`Analysis/NormedSpace/CoveringNumber/L1.lean`) — statement *and* proof are
  character-for-character identical, in two different layers. Not in Mathlib, so one must
  stay; which layer owns it is an `ARCHITECTURE.md` question.
- Two `Real.exp` inequalities proved twice: ~92 lines in
  `Probability/RandomMatrix/Bernstein.lean` and ~96 lines in
  `Probability/Concentration/Bernstein.lean`, with no import between the modules. They carry
  no probabilistic content and arguably belong in `Analysis/`, imported by both — again a
  placement call.

## Verification

- `lake build` green across all 8,811 jobs, no warnings.
- No remaining reference to any removed name anywhere in the repository, docstrings included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
